### PR TITLE
Enhance type safety in the Request method, and fixed require problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metaphor-node
 
-Our official Node SDK. Uses axios under the hood.
+Our official Node SDK. Uses node-fetch under the hood.
 
 https://www.npmjs.com/package/metaphor-node
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -68,4 +68,4 @@ class Metaphor {
         return await this.request(`/contents?${params}`, 'GET');
     }
 }
-exports.default = Metaphor;
+module.exports = Metaphor;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "metaphor-node",
-	"version": "1.0.19",
+	"version": "1.0.20",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "metaphor-node",
-			"version": "1.0.19",
+			"version": "1.0.20",
 			"license": "ISC",
 			"devDependencies": {
 				"@types/node-fetch": "^2.6.4",
-				"node-fetch": "^2.6.12"
+				"node-fetch": "^2.6.7"
 			}
 		},
 		"node_modules/@types/node": {
@@ -92,9 +92,9 @@
 			}
 		},
 		"node_modules/node-fetch": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
 			"dependencies": {
 				"whatwg-url": "^5.0.0"
@@ -199,9 +199,9 @@
 			}
 		},
 		"node-fetch": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
-			"integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+			"version": "2.6.7",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
 			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
 	"homepage": "https://github.com/metaphorsystems/metaphor-node#readme",
 	"devDependencies": {
 		"@types/node-fetch": "^2.6.4",
-		"node-fetch": "^2.6.12"
+		"node-fetch": "^2.6.7"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,11 +72,11 @@ export default class Metaphor {
     });
   }
 
-  private async request(
+ private async request<T>(
     endpoint: string,
     method: string,
     body?: any
-  ): Promise<any> {
+  ): Promise<T> {
     const response = await fetch(this.baseURL + endpoint, {
       method,
       headers: this.headers,
@@ -84,11 +84,13 @@ export default class Metaphor {
     });
 
     if (!response.ok) {
-      const message = (await response.json()).error;
+      const errorData = (await response.json()) as { error: string };
+      const message = errorData.error
       throw new Error(`Request failed with status ${response.status}. ${message}`);
     }
 
-    return await response.json();
+    return response.json() as T;
+
   }
 
   async search(


### PR DESCRIPTION
Aiming to improve type safety in the `request` method by adding type annotations and assertions, making the code more reliable and maintainable. No more "_Object is of type 'unknown_'" error. 
Also fixed **require** problem arising from node-fetch's latest versions that not supporting **require** anymore.
