### PR TITLE
Fix: Add costDollars to AnswerResponse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -322,6 +322,7 @@ export type AnswerOptions = {
  * @typedef {Object} AnswerResponse
  * @property {string} answer - The generated answer text.
  * @property {SearchResult<{}>[]} citations - The sources used to generate the answer.
+ * @property {CostDollars} [costDollars] - The cost breakdown for this request.
  * @property {string} [requestId] - Optional request ID for the answer.
  */
 export type AnswerResponse = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,6 +328,7 @@ export type AnswerResponse = {
   answer: string;
   citations: SearchResult<{}>[];
   requestId?: string;
+  costDollars?: CostDollars;
 };
 
 export type AnswerStreamChunk = {


### PR DESCRIPTION
<img width="638" alt="image" src="https://github.com/user-attachments/assets/00a3e455-bd6a-40e6-8e4e-8cf6a31f2120" />

Actual response:

```
{
  requestId: "8e62fc40-8d57-4a25-96bc-94d2ea144573",
  answer: "Paris is the capital of France. ([en.wikipedia.org](https://en.wikipedia.org/wiki/Paris), [britannica.com](https://www.britannica.com/place/Paris), [coe.int](https://www.coe.int/en/web/interculturalcities/paris))",
  citations: [ (stripped for brevity) ],
  costDollars: {
    total: 0.005,
  },
}
```