### PR TITLE
Add context content type support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export type ExtrasOptions = { links?: number; imageLinks?: number };
  * @property {TextContentsOptions | boolean} [text] - Options for retrieving text contents.
  * @property {HighlightsContentsOptions | boolean} [highlights] - Options for retrieving highlights.
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
+ * @property {ContextContentsOptions | boolean} [context] - Options for retrieving a combined context string.
  * @property {LivecrawlOptions} [livecrawl] - Options for livecrawling contents. Default is "never" for neural/auto search, "fallback" for keyword search.
  * @property {number} [livecrawlTimeout] - The timeout for livecrawling. Max and default is 10000ms.
  * @property {boolean} [filterEmptyResults] - If true, filters out results with no contents. Default is true.
@@ -91,6 +92,7 @@ export type ContentsOptions = {
   text?: TextContentsOptions | true;
   highlights?: HighlightsContentsOptions | true;
   summary?: SummaryContentsOptions | true;
+  context?: ContextContentsOptions | true;
   livecrawl?: LivecrawlOptions;
   livecrawlTimeout?: number;
   filterEmptyResults?: boolean;
@@ -170,6 +172,15 @@ export type SummaryContentsOptions = {
 };
 
 /**
+ * Options for retrieving a combined context string.
+ * @typedef {Object} ContextContentsOptions
+ * @property {number} [maxCharacters] - Maximum character limit for the context string.
+ */
+export type ContextContentsOptions = {
+  maxCharacters?: number;
+};
+
+/**
  * @typedef {Object} TextResponse
  * @property {string} text - Text from page
  */
@@ -190,6 +201,12 @@ export type HighlightsResponse = {
  * @property {string} summary - The generated summary of the page content.
  */
 export type SummaryResponse = { summary: string };
+
+/**
+ * @typedef {Object} ContextResponse
+ * @property {string} context - Combined context string of the search result and any subpages.
+ */
+export type ContextResponse = { context: string };
 
 /**
  * @typedef {Object} ExtrasResponse
@@ -220,6 +237,7 @@ export type ContentsResultComponent<T extends ContentsOptions> = Default<
   (T["text"] extends object | true ? TextResponse : {}) &
     (T["highlights"] extends object | true ? HighlightsResponse : {}) &
     (T["summary"] extends object | true ? SummaryResponse : {}) &
+    (T["context"] extends object | true ? ContextResponse : {}) &
     (T["subpages"] extends number ? SubpagesResponse<T> : {}) &
     (T["extras"] extends object ? ExtrasResponse : {}),
   TextResponse
@@ -293,6 +311,7 @@ export type SearchResult<T extends ContentsOptions> = {
  * @property {Result[]} results - The list of search results.
  * @property {string} [autopromptString] - The autoprompt string, if applicable.
  * @property {string} [autoDate] - The autoprompt date, if applicable.
+ * @property {string} [context] - Combined context string of the search result and any subpages.
  * @property {string} requestId - The request ID for the search.
  * @property {CostDollars} [costDollars] - The cost breakdown for this request.
  */
@@ -300,6 +319,7 @@ export type SearchResponse<T extends ContentsOptions> = {
   results: SearchResult<T>[];
   autopromptString?: string;
   autoDate?: string;
+  context?: string;
   requestId: string;
   costDollars?: CostDollars;
 };
@@ -395,6 +415,7 @@ export class Exa {
       text,
       highlights,
       summary,
+      context,
       subpages,
       subpageTarget,
       extras,
@@ -410,7 +431,8 @@ export class Exa {
       text === undefined &&
       summary === undefined &&
       highlights === undefined &&
-      extras === undefined
+      extras === undefined &&
+      context === undefined
     ) {
       contentsOptions.text = true;
     }
@@ -418,6 +440,7 @@ export class Exa {
     if (text !== undefined) contentsOptions.text = text;
     if (summary !== undefined) contentsOptions.summary = summary;
     if (highlights !== undefined) contentsOptions.highlights = highlights;
+    if (context !== undefined) contentsOptions.context = context;
     if (subpages !== undefined) contentsOptions.subpages = subpages;
     if (subpageTarget !== undefined)
       contentsOptions.subpageTarget = subpageTarget;


### PR DESCRIPTION
## Summary
- support a new `context` content type in `ContentsOptions`
- expose the combined `context` string on `SearchResponse`
- handle context option when building contents requests

## Testing
- `npm run build-fast` *(fails: tsup not found)*
- `npm test` *(fails: vitest not found)*