### PR TITLE
[answer] remove public mentions of exa-pro but still accept type for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,6 @@ const answerResult = await exa.answer(
   "What is the population of New York City?"
 );
 
-// Get answer with citation contents and use the exa-pro model, which passes 2 extra queries to exa to increase coverage of the search space.
-const answerWithTextResults = await exa.answer(
-  "What is the population of New York City?",
-  {
-    text: true,
-    model: "exa-pro",
-  }
-);
-
 // Get an answer with streaming
 for await (const chunk of exa.streamAnswer(
   "What is the population of New York City?"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"

--- a/src/index.ts
+++ b/src/index.ts
@@ -334,14 +334,14 @@ export type Status = {
  * @typedef {Object} AnswerOptions
  * @property {boolean} [stream] - Whether to stream the response. Default false.
  * @property {boolean} [text] - Whether to include text in the source results. Default false.
- * @property {"exa" | "exa-pro"} [model] - The model to use for generating the answer. Default "exa".
+ * @property {"exa"} [model] - The model to use for generating the answer. Default "exa".
  * @property {string} [systemPrompt] - A system prompt to guide the LLM's behavior when generating the answer.
  * @property {Object} [outputSchema] - A JSON Schema specification for the structure you expect the output to take
  */
 export type AnswerOptions = {
   stream?: boolean;
   text?: boolean;
-  model?: "exa" | "exa-pro";
+  model?: "exa";
   systemPrompt?: string;
   outputSchema?: Record<string, unknown>;
 };
@@ -710,7 +710,7 @@ export class Exa {
    * ```ts
    * const answer = await exa.answer("What is quantum computing?", {
    *   text: true,
-   *   model: "exa-pro",
+   *   model: "exa",
    *   systemPrompt: "Answer in a technical manner suitable for experts."
    * });
    * ```


### PR DESCRIPTION
We're still supporting this, just removing from examples.