### PR TITLE
Update js sdk for argument consistency

### DIFF
--- a/REFACTORING_SUMMARY.md
+++ b/REFACTORING_SUMMARY.md
@@ -1,0 +1,73 @@
+# JavaScript SDK Spread Operator Refactoring
+
+## Overview
+Successfully removed all usages of the spread operator (`...`) in the JavaScript SDK to match the changes made in the Python SDK. This refactoring improves forward compatibility and reduces the risk of errors when API responses contain unexpected fields.
+
+## Changes Made
+
+### 1. Main API Methods (`src/index.ts`)
+
+#### `search()` method
+- **Before**: `{ query, ...options }`
+- **After**: Explicit property assignment for all BaseSearchOptions and RegularSearchOptions properties
+- Properties handled: `numResults`, `includeDomains`, `excludeDomains`, `startCrawlDate`, `endCrawlDate`, `startPublishedDate`, `endPublishedDate`, `category`, `includeText`, `excludeText`, `flags`, `moderation`, `useAutoprompt`, `type`
+
+#### `searchAndContents()` method
+- **Before**: `{ query, contents: contentsOptions, ...restOptions }`
+- **After**: Explicit property assignment for all search options excluding contents properties
+- Same properties as search method (excluding contents-specific options)
+
+#### `findSimilar()` method
+- **Before**: `{ url, ...options }`
+- **After**: Explicit property assignment for all BaseSearchOptions and FindSimilarOptions properties
+- Properties handled: All BaseSearchOptions properties plus `excludeSourceDomain`
+
+#### `findSimilarAndContents()` method
+- **Before**: `{ url, contents: contentsOptions, ...restOptions }`
+- **After**: Explicit property assignment for all search options excluding contents properties
+- Same properties as findSimilar method (excluding contents-specific options)
+
+#### `getContents()` method
+- **Before**: `{ urls: requestUrls, ...options }`
+- **After**: Explicit property assignment for all ContentsOptions properties
+- Properties handled: `text`, `highlights`, `summary`, `livecrawl`, `context`, `livecrawlTimeout`, `filterEmptyResults`, `subpages`, `subpageTarget`, `extras`
+
+#### `extractContentsOptions()` helper method
+- **Before**: Used destructuring with spread operator (`...rest`)
+- **After**: Manual property extraction using a loop and Set-based filtering
+- Maintains the same functionality while avoiding spread operator
+
+### 2. Websets API Methods
+
+#### `src/websets/webhooks.ts`
+- **Methods**: `listAll()`, `listAllAttempts()`
+- **Before**: `{ ...options }`
+- **After**: Explicit property assignment for pagination options (`cursor`, `limit`, `eventType`)
+
+#### `src/websets/items.ts`
+- **Method**: `listAll()`
+- **Before**: `{ ...options }`
+- **After**: Explicit property assignment for pagination options (`cursor`, `limit`)
+
+#### `src/websets/client.ts`
+- **Method**: `listAll()`
+- **Before**: `{ ...options }`
+- **After**: Explicit property assignment for pagination options (`cursor`, `limit`)
+
+## Benefits
+
+1. **Forward Compatibility**: The SDK now handles API responses with unknown fields gracefully without spreading them into request objects
+2. **Type Safety**: Explicit property assignment provides better type checking and IDE support
+3. **Predictable Behavior**: Removes the risk of accidentally passing unwanted properties from API responses to subsequent requests
+4. **Consistency**: Aligns the JavaScript SDK behavior with the Python SDK
+
+## Verification
+
+- ✅ TypeScript compilation successful
+- ✅ Build process completed without errors
+- ✅ All spread operators successfully removed
+- ✅ Maintains existing API interface and functionality
+
+## Testing
+
+The refactored code maintains the same public API interface, so existing user code should continue to work without changes. All method signatures and return types remain identical.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "1.8.15",
+      "version": "1.8.16",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -416,46 +416,46 @@ export class Exa {
     contentsOptions: ContentsOptions;
     restOptions: Omit<T, keyof ContentsOptions>;
   } {
-    const {
-      text,
-      highlights,
-      summary,
-      subpages,
-      subpageTarget,
-      extras,
-      livecrawl,
-      livecrawlTimeout,
-      context,
-      ...rest
-    } = options;
-
     const contentsOptions: ContentsOptions = {};
 
     // Default: if none of text, summary, or highlights is provided, we retrieve text
     if (
-      text === undefined &&
-      summary === undefined &&
-      highlights === undefined &&
-      extras === undefined
+      options.text === undefined &&
+      options.summary === undefined &&
+      options.highlights === undefined &&
+      options.extras === undefined
     ) {
       contentsOptions.text = true;
     }
 
-    if (text !== undefined) contentsOptions.text = text;
-    if (summary !== undefined) contentsOptions.summary = summary;
-    if (highlights !== undefined) contentsOptions.highlights = highlights;
-    if (subpages !== undefined) contentsOptions.subpages = subpages;
-    if (subpageTarget !== undefined)
-      contentsOptions.subpageTarget = subpageTarget;
-    if (extras !== undefined) contentsOptions.extras = extras;
-    if (livecrawl !== undefined) contentsOptions.livecrawl = livecrawl;
-    if (livecrawlTimeout !== undefined)
-      contentsOptions.livecrawlTimeout = livecrawlTimeout;
-    if (context !== undefined) contentsOptions.context = context;
+    if (options.text !== undefined) contentsOptions.text = options.text;
+    if (options.summary !== undefined) contentsOptions.summary = options.summary;
+    if (options.highlights !== undefined) contentsOptions.highlights = options.highlights;
+    if (options.subpages !== undefined) contentsOptions.subpages = options.subpages;
+    if (options.subpageTarget !== undefined)
+      contentsOptions.subpageTarget = options.subpageTarget;
+    if (options.extras !== undefined) contentsOptions.extras = options.extras;
+    if (options.livecrawl !== undefined) contentsOptions.livecrawl = options.livecrawl;
+    if (options.livecrawlTimeout !== undefined)
+      contentsOptions.livecrawlTimeout = options.livecrawlTimeout;
+    if (options.context !== undefined) contentsOptions.context = options.context;
+
+    // Manually build restOptions by excluding the contents-specific properties
+    const restOptions: any = {};
+    const contentKeys = new Set([
+      'text', 'highlights', 'summary', 'subpages', 'subpageTarget', 
+      'extras', 'livecrawl', 'livecrawlTimeout', 'context'
+    ]);
+    
+    for (const key in options) {
+      if (options.hasOwnProperty(key) && !contentKeys.has(key)) {
+        restOptions[key] = options[key];
+      }
+    }
 
     return {
       contentsOptions,
-      restOptions: rest as Omit<T, keyof ContentsOptions>,
+      restOptions: restOptions as Omit<T, keyof ContentsOptions>,
     };
   }
 
@@ -604,7 +604,23 @@ export class Exa {
     query: string,
     options?: RegularSearchOptions
   ): Promise<SearchResponse<{}>> {
-    return await this.request("/search", "POST", { query, ...options });
+    const payload: any = { query };
+    if (options?.numResults !== undefined) payload.numResults = options.numResults;
+    if (options?.includeDomains !== undefined) payload.includeDomains = options.includeDomains;
+    if (options?.excludeDomains !== undefined) payload.excludeDomains = options.excludeDomains;
+    if (options?.startCrawlDate !== undefined) payload.startCrawlDate = options.startCrawlDate;
+    if (options?.endCrawlDate !== undefined) payload.endCrawlDate = options.endCrawlDate;
+    if (options?.startPublishedDate !== undefined) payload.startPublishedDate = options.startPublishedDate;
+    if (options?.endPublishedDate !== undefined) payload.endPublishedDate = options.endPublishedDate;
+    if (options?.category !== undefined) payload.category = options.category;
+    if (options?.includeText !== undefined) payload.includeText = options.includeText;
+    if (options?.excludeText !== undefined) payload.excludeText = options.excludeText;
+    if (options?.flags !== undefined) payload.flags = options.flags;
+    if (options?.moderation !== undefined) payload.moderation = options.moderation;
+    if (options?.useAutoprompt !== undefined) payload.useAutoprompt = options.useAutoprompt;
+    if (options?.type !== undefined) payload.type = options.type;
+    
+    return await this.request("/search", "POST", payload);
   }
 
   /**
@@ -623,11 +639,27 @@ export class Exa {
         ? { contentsOptions: { text: true }, restOptions: {} }
         : this.extractContentsOptions(options);
 
-    return await this.request("/search", "POST", {
+    const payload: any = {
       query,
       contents: contentsOptions,
-      ...restOptions,
-    });
+    };
+    
+    if (restOptions.numResults !== undefined) payload.numResults = restOptions.numResults;
+    if (restOptions.includeDomains !== undefined) payload.includeDomains = restOptions.includeDomains;
+    if (restOptions.excludeDomains !== undefined) payload.excludeDomains = restOptions.excludeDomains;
+    if (restOptions.startCrawlDate !== undefined) payload.startCrawlDate = restOptions.startCrawlDate;
+    if (restOptions.endCrawlDate !== undefined) payload.endCrawlDate = restOptions.endCrawlDate;
+    if (restOptions.startPublishedDate !== undefined) payload.startPublishedDate = restOptions.startPublishedDate;
+    if (restOptions.endPublishedDate !== undefined) payload.endPublishedDate = restOptions.endPublishedDate;
+    if (restOptions.category !== undefined) payload.category = restOptions.category;
+    if (restOptions.includeText !== undefined) payload.includeText = restOptions.includeText;
+    if (restOptions.excludeText !== undefined) payload.excludeText = restOptions.excludeText;
+    if (restOptions.flags !== undefined) payload.flags = restOptions.flags;
+    if (restOptions.moderation !== undefined) payload.moderation = restOptions.moderation;
+    if (restOptions.useAutoprompt !== undefined) payload.useAutoprompt = restOptions.useAutoprompt;
+    if (restOptions.type !== undefined) payload.type = restOptions.type;
+
+    return await this.request("/search", "POST", payload);
   }
 
   /**
@@ -640,7 +672,21 @@ export class Exa {
     url: string,
     options?: FindSimilarOptions
   ): Promise<SearchResponse<{}>> {
-    return await this.request("/findSimilar", "POST", { url, ...options });
+    const payload: any = { url };
+    if (options?.numResults !== undefined) payload.numResults = options.numResults;
+    if (options?.includeDomains !== undefined) payload.includeDomains = options.includeDomains;
+    if (options?.excludeDomains !== undefined) payload.excludeDomains = options.excludeDomains;
+    if (options?.startCrawlDate !== undefined) payload.startCrawlDate = options.startCrawlDate;
+    if (options?.endCrawlDate !== undefined) payload.endCrawlDate = options.endCrawlDate;
+    if (options?.startPublishedDate !== undefined) payload.startPublishedDate = options.startPublishedDate;
+    if (options?.endPublishedDate !== undefined) payload.endPublishedDate = options.endPublishedDate;
+    if (options?.category !== undefined) payload.category = options.category;
+    if (options?.includeText !== undefined) payload.includeText = options.includeText;
+    if (options?.excludeText !== undefined) payload.excludeText = options.excludeText;
+    if (options?.flags !== undefined) payload.flags = options.flags;
+    if (options?.excludeSourceDomain !== undefined) payload.excludeSourceDomain = options.excludeSourceDomain;
+    
+    return await this.request("/findSimilar", "POST", payload);
   }
 
   /**
@@ -658,11 +704,25 @@ export class Exa {
         ? { contentsOptions: { text: true }, restOptions: {} }
         : this.extractContentsOptions(options);
 
-    return await this.request("/findSimilar", "POST", {
+    const payload: any = {
       url,
       contents: contentsOptions,
-      ...restOptions,
-    });
+    };
+    
+    if (restOptions.numResults !== undefined) payload.numResults = restOptions.numResults;
+    if (restOptions.includeDomains !== undefined) payload.includeDomains = restOptions.includeDomains;
+    if (restOptions.excludeDomains !== undefined) payload.excludeDomains = restOptions.excludeDomains;
+    if (restOptions.startCrawlDate !== undefined) payload.startCrawlDate = restOptions.startCrawlDate;
+    if (restOptions.endCrawlDate !== undefined) payload.endCrawlDate = restOptions.endCrawlDate;
+    if (restOptions.startPublishedDate !== undefined) payload.startPublishedDate = restOptions.startPublishedDate;
+    if (restOptions.endPublishedDate !== undefined) payload.endPublishedDate = restOptions.endPublishedDate;
+    if (restOptions.category !== undefined) payload.category = restOptions.category;
+    if (restOptions.includeText !== undefined) payload.includeText = restOptions.includeText;
+    if (restOptions.excludeText !== undefined) payload.excludeText = restOptions.excludeText;
+    if (restOptions.flags !== undefined) payload.flags = restOptions.flags;
+    if (restOptions.excludeSourceDomain !== undefined) payload.excludeSourceDomain = restOptions.excludeSourceDomain;
+
+    return await this.request("/findSimilar", "POST", payload);
   }
 
   /**
@@ -692,10 +752,20 @@ export class Exa {
       requestUrls = (urls as SearchResult<T>[]).map((result) => result.url);
     }
 
-    const payload = {
+    const payload: any = {
       urls: requestUrls,
-      ...options,
     };
+
+    if (options?.text !== undefined) payload.text = options.text;
+    if (options?.highlights !== undefined) payload.highlights = options.highlights;
+    if (options?.summary !== undefined) payload.summary = options.summary;
+    if (options?.livecrawl !== undefined) payload.livecrawl = options.livecrawl;
+    if (options?.context !== undefined) payload.context = options.context;
+    if (options?.livecrawlTimeout !== undefined) payload.livecrawlTimeout = options.livecrawlTimeout;
+    if (options?.filterEmptyResults !== undefined) payload.filterEmptyResults = options.filterEmptyResults;
+    if (options?.subpages !== undefined) payload.subpages = options.subpages;
+    if (options?.subpageTarget !== undefined) payload.subpageTarget = options.subpageTarget;
+    if (options?.extras !== undefined) payload.extras = options.extras;
 
     return await this.request("/contents", "POST", payload);
   }

--- a/src/websets/client.ts
+++ b/src/websets/client.ts
@@ -129,7 +129,10 @@ export class WebsetsClient extends WebsetsBaseClient {
    */
   async *listAll(options?: ListWebsetsOptions): AsyncGenerator<Webset> {
     let cursor: string | undefined = undefined;
-    const pageOptions = options ? { ...options } : {};
+    const pageOptions: any = {};
+    
+    if (options?.cursor !== undefined) pageOptions.cursor = options.cursor;
+    if (options?.limit !== undefined) pageOptions.limit = options.limit;
 
     while (true) {
       pageOptions.cursor = cursor;

--- a/src/websets/items.ts
+++ b/src/websets/items.ts
@@ -38,7 +38,10 @@ export class WebsetItemsClient extends WebsetsBaseClient {
     options?: PaginationParams
   ): AsyncGenerator<WebsetItem> {
     let cursor: string | undefined = undefined;
-    const pageOptions = options ? { ...options } : {};
+    const pageOptions: any = {};
+    
+    if (options?.cursor !== undefined) pageOptions.cursor = options.cursor;
+    if (options?.limit !== undefined) pageOptions.limit = options.limit;
 
     while (true) {
       pageOptions.cursor = cursor;

--- a/src/websets/webhooks.ts
+++ b/src/websets/webhooks.ts
@@ -71,7 +71,10 @@ export class WebsetWebhooksClient extends WebsetsBaseClient {
    */
   async *listAll(options?: ListWebhooksOptions): AsyncGenerator<Webhook> {
     let cursor: string | undefined = undefined;
-    const pageOptions = options ? { ...options } : {};
+    const pageOptions: any = {};
+    
+    if (options?.cursor !== undefined) pageOptions.cursor = options.cursor;
+    if (options?.limit !== undefined) pageOptions.limit = options.limit;
 
     while (true) {
       pageOptions.cursor = cursor;
@@ -156,7 +159,11 @@ export class WebsetWebhooksClient extends WebsetsBaseClient {
     options?: ListWebhookAttemptsOptions
   ): AsyncGenerator<WebhookAttempt> {
     let cursor: string | undefined = undefined;
-    const pageOptions = options ? { ...options } : {};
+    const pageOptions: any = {};
+    
+    if (options?.cursor !== undefined) pageOptions.cursor = options.cursor;
+    if (options?.limit !== undefined) pageOptions.limit = options.limit;
+    if (options?.eventType !== undefined) pageOptions.eventType = options.eventType;
 
     while (true) {
       pageOptions.cursor = cursor;


### PR DESCRIPTION
The JavaScript SDK was refactored to remove all usages of the spread operator (`...`) and replace them with explicit argument passing. This change aligns the SDK with the Python SDK's recent updates, improving forward compatibility and type safety by preventing accidental property passing from API responses to requests.

Key changes include:

*   **Main API Methods (`src/index.ts`)**:
    *   `search()`, `searchAndContents()`, `findSimilar()`, `findSimilarAndContents()`, and `getContents()` methods now explicitly assign each option property (e.g., `numResults`, `includeDomains`, `text`) to the payload object instead of using the spread operator.
    *   The `extractContentsOptions()` helper function was refactored to manually extract content-specific properties and build `restOptions` using a loop and `Set`-based filtering, avoiding destructuring with spread.
*   **Websets API Methods**:
    *   `listAll()` in `src/websets/client.ts` and `src/websets/items.ts` now explicitly assigns `cursor` and `limit` pagination options.
    *   `listAll()` and `listAllAttempts()` in `src/websets/webhooks.ts` explicitly assign `cursor`, `limit`, and `eventType` pagination options.

This refactoring ensures the SDK remains robust when new fields are introduced in API responses and enhances type checking. The changes maintain the existing public API interface.