### PR TITLE
Update default search comment to auto

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -660,7 +660,11 @@ export class Exa {
     query: string,
     options?: RegularSearchOptions
   ): Promise<SearchResponse<{}>> {
-    return await this.request("/search", "POST", { query, ...options });
+    const payload =
+      options === undefined || options.type === undefined
+        ? { query, type: "auto", ...(options ?? {}) }
+        : { query, ...options };
+    return await this.request("/search", "POST", payload);
   }
 
   /**
@@ -679,10 +683,16 @@ export class Exa {
         ? { contentsOptions: { text: true }, restOptions: {} }
         : this.extractContentsOptions(options);
 
+    const finalRestOptions: typeof restOptions & { type?: RegularSearchOptions["type"] } =
+      { ...(restOptions as any) };
+    if (finalRestOptions.type === undefined) {
+      finalRestOptions.type = "auto";
+    }
+
     return await this.request("/search", "POST", {
       query,
       contents: contentsOptions,
-      ...restOptions,
+      ...finalRestOptions,
     });
   }
 

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -39,6 +39,7 @@ describe("Search API", () => {
     expect(requestSpy).toHaveBeenCalledWith("/search", "POST", {
       query: "latest AI developments",
       numResults: 2,
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });
@@ -71,6 +72,7 @@ describe("Search API", () => {
         text: true,
       },
       numResults: 2,
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });
@@ -106,6 +108,7 @@ describe("Search API", () => {
         context: true,
       },
       numResults: 2,
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });
@@ -147,6 +150,7 @@ describe("Search API", () => {
         context: { maxCharacters: 500 },
       },
       numResults: 3,
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });
@@ -175,6 +179,7 @@ describe("Search API", () => {
       contents: {
         text: true,
       },
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });
@@ -246,6 +251,7 @@ describe("Search API", () => {
         livecrawlTimeout: 8000,
       },
       numResults: 3,
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });
@@ -304,6 +310,7 @@ describe("Search API", () => {
       query: "local news",
       userLocation: "US",
       numResults: 5,
+      type: "auto",
     });
     expect(result).toEqual(mockResponse);
   });


### PR DESCRIPTION
Set the default search type to `auto` for `search` and `searchAndContents` methods.

---
[Slack Thread](https://exa-labs-inc.slack.com/archives/C090Z3VH487/p1754668934719769?thread_ts=1754668934.719769&cid=C090Z3VH487)

<a href="https://cursor.com/background-agent?bcId=bc-e52653d9-18b0-41ef-aaf7-d2ae3ac5be82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e52653d9-18b0-41ef-aaf7-d2ae3ac5be82">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

