### PR TITLE
[exa-js]: Add people category and remove linkedin profile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export type ContentsOptions = {
  * @property {string} [endCrawlDate] - End date for results based on crawl date.
  * @property {string} [startPublishedDate] - Start date for results based on published date.
  * @property {string} [endPublishedDate] - End date for results based on published date.
- * @property {string} [category] - A data category to focus on, with higher comprehensivity and data cleanliness. Currently, the only category is company.
+ * @property {string} [category] - A data category to focus on, with higher comprehensivity and data cleanliness.
  * @property {string[]} [includeText] - List of strings that must be present in webpage text of results. Currently only supports 1 string of up to 5 words.
  * @property {string[]} [excludeText] - List of strings that must not be present in webpage text of results. Currently only supports 1 string of up to 5 words.
  * @property {string[]} [flags] - Experimental flags
@@ -74,8 +74,8 @@ export type BaseSearchOptions = {
     | "github"
     | "tweet"
     | "personal site"
-    | "linkedin profile"
-    | "financial report";
+    | "financial report"
+    | "people";
   includeText?: string[];
   excludeText?: string[];
   flags?: string[];


### PR DESCRIPTION
## Summary

Updates the SDK category enum to support the new `people` entity search and removes the deprecated `linkedin profile` category. This aligns with the backend changes in the `entities/return-company-contents` branch.

Changes across 3 repos:
- **exa-py**: Updated category comment in `api.py`
- **exa-js**: Updated TypeScript union type and JSDoc in `index.ts`
- **docs**: Updated OpenAPI spec enum in `exa-spec.yaml`

## Review & Testing Checklist for Human

- [ ] Verify "people" is the correct category name used in `entities/return-company-contents` branch (check `categories.ts` in vulcan)
- [ ] Test SDK with `category: "people"` against the entities branch deployment before merging
- [ ] Coordinate merging all 3 PRs (exa-py, exa-js, docs) together to keep spec in sync
- [ ] Confirm no other references to "linkedin profile" exist in the SDKs that need updating

**Recommended test plan:** Deploy entities/return-company-contents via tilt, then run a search request with `category: "people"` using both Python and JS SDKs to verify end-to-end functionality.

### Notes

- Tilt deployment was still building when PRs were created - testing against local deployment was not completed
- Pre-existing typecheck errors in exa-js test files are unrelated to these changes

Link to Devin run: https://app.devin.ai/sessions/2cfad87862c449d98e76fb8be776501d
Requested by: conrad@exa.ai (@conradsoon)