### PR TITLE
fix: make highlightScores optional in HighlightsResponse

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,11 +214,11 @@ export type TextResponse = { text: string };
 /**
  * @typedef {Object} HighlightsResponse
  * @property {string[]} highlights - The highlights as an array of strings.
- * @property {number[]} highlightScores - The corresponding scores as an array of floats, 0 to 1
+ * @property {number[]} [highlightScores] - The corresponding scores as an array of floats, 0 to 1
  */
 export type HighlightsResponse = {
   highlights: string[];
-  highlightScores: number[];
+  highlightScores?: number[];
 };
 
 /**


### PR DESCRIPTION
## Summary
- Make `highlightScores` field optional in `HighlightsResponse` type to match backend API schema
- The backend may not always return `highlightScores`, so the SDK type should reflect this

## Test plan
- [x] All existing unit tests pass (including 4 highlights tests)
- [x] TypeScript compilation succeeds