### PR TITLE
Add linkPolicy to HighlightsContentsOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,11 +172,13 @@ export type TextContentsOptions = {
  * @property {string} [query] - The query string to use for highlights search.
  * @property {number} [numSentences] - The number of sentences to return for each highlight.
  * @property {number} [highlightsPerUrl] - The number of highlights to return for each URL.
+ * @property {"strip" | "keep"} [linkPolicy] - Whether to strip or keep links in the highlights.
  */
 export type HighlightsContentsOptions = {
   query?: string;
   numSentences?: number;
   highlightsPerUrl?: number;
+  linkPolicy?: "strip" | "keep";
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds `linkPolicy` option to highlights configuration across all SDKs and documentation. This allows users to control whether links are stripped or kept in highlight snippets.

**Changes:**
- `monorepo`: Added `linkPolicy?: "strip" | "keep"` to `HighlightsContentsOptions` in shared types
- `docs`: Added `linkPolicy` enum field to highlights schema in `exa-spec.yaml`
- `exa-js`: Added `linkPolicy` to `HighlightsContentsOptions` type with JSDoc
- `exa-py`: Added `link_policy: Literal["strip", "keep"]` to `HighlightsContentsOptions`

The backend (vulcan) already supports this field via `UrlPolicySchema` in `requests.ts`.

## Review & Testing Checklist for Human

- [ ] Verify backend actually processes `linkPolicy` correctly (vulcan has the schema but confirm it's wired through to snippet generation)
- [ ] Test with `linkPolicy: "strip"` via API call to confirm links are removed from highlights
- [ ] Confirm default behavior matches docs ("keep" by default)

### Notes

This is a type-only change exposing an existing backend capability to SDK users.

**Link to Devin run:** https://app.devin.ai/sessions/3d9a8bd68822476a9383ea8a4631e8e1
**Requested by:** liam@exa.ai (@LiamHz)