### PR TITLE
feat: add maxCacheAge parameter to SDK

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
  * @property {LivecrawlOptions} [livecrawl] - Options for livecrawling contents. Default is "never" for neural/auto search, "fallback" for keyword search.
  * @property {number} [livecrawlTimeout] - The timeout for livecrawling. Max and default is 10000ms.
- * @property {number} [maxCacheAge] - Maximum age of cached content (in seconds) before triggering a live crawl. Default is 604800 (7 days).
+ * @property {number} [maxCacheAge] - Maximum age of cached content (in hours) before triggering a live crawl. Default is 168 (7 days).
  * @property {boolean} [filterEmptyResults] - If true, filters out results with no contents. Default is true.
  * @property {number} [subpages] - The number of subpages to return for each result, where each subpage is derived from an internal link for the result.
  * @property {string | string[]} [subpageTarget] - Text used to match/rank subpages in the returned subpage list. You could use "about" to get *about* page for websites. Note that this is a fuzzy matcher.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
  * @property {LivecrawlOptions} [livecrawl] - Options for livecrawling contents. Default is "never" for neural/auto search, "fallback" for keyword search.
  * @property {number} [livecrawlTimeout] - The timeout for livecrawling. Max and default is 10000ms.
+ * @property {number} [maxCacheAge] - Maximum age of cached content (in seconds) before triggering a live crawl. Default is 604800 (7 days).
  * @property {boolean} [filterEmptyResults] - If true, filters out results with no contents. Default is true.
  * @property {number} [subpages] - The number of subpages to return for each result, where each subpage is derived from an internal link for the result.
  * @property {string | string[]} [subpageTarget] - Text used to match/rank subpages in the returned subpage list. You could use "about" to get *about* page for websites. Note that this is a fuzzy matcher.
@@ -34,6 +35,7 @@ export type ContentsOptions = {
   livecrawl?: LivecrawlOptions;
   context?: ContextOptions | true;
   livecrawlTimeout?: number;
+  maxCacheAge?: number;
   filterEmptyResults?: boolean;
   subpages?: number;
   subpageTarget?: string | string[];
@@ -470,6 +472,7 @@ export class Exa {
       extras,
       livecrawl,
       livecrawlTimeout,
+      maxCacheAge,
       context,
       ...rest
     } = options;
@@ -512,6 +515,7 @@ export class Exa {
     if (livecrawl !== undefined) contentsOptions.livecrawl = livecrawl;
     if (livecrawlTimeout !== undefined)
       contentsOptions.livecrawlTimeout = livecrawlTimeout;
+    if (maxCacheAge !== undefined) contentsOptions.maxCacheAge = maxCacheAge;
     if (context !== undefined) contentsOptions.context = context;
 
     return {


### PR DESCRIPTION
# feat: add maxCacheAge parameter to SDK

## Summary
Adds the `maxCacheAge` parameter to the JavaScript SDK, allowing users to control cache freshness for content retrieval. This parameter specifies the maximum age (in seconds) of cached content before triggering a live crawl.

Changes:
- Added `maxCacheAge?: number` to `ContentsOptions` type
- Added JSDoc documentation for the parameter
- Added `maxCacheAge` to `extractContentsOptions` destructuring and assignment
