### PR TITLE
feat: add maxCharacters param for highlights, deprecate numSentences/highlightsPerUrl

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -170,12 +170,16 @@ export type TextContentsOptions = {
  * to your initial query, and may vary in quantity and length.
  * @typedef {Object} HighlightsContentsOptions
  * @property {string} [query] - The query string to use for highlights search.
- * @property {number} [numSentences] - The number of sentences to return for each highlight.
- * @property {number} [highlightsPerUrl] - The number of highlights to return for each URL.
+ * @property {number} [maxCharacters] - Maximum total characters across all highlights per URL. Characters are distributed across multiple non-contiguous highlights (default 5). If the full page is shorter than maxCharacters, the entire page is returned. Default is 2000.
+ * @property {number} [numSentences] - Deprecated: use maxCharacters instead. The number of sentences to return for each highlight.
+ * @property {number} [highlightsPerUrl] - Deprecated: use maxCharacters instead. The number of highlights to return for each URL.
  */
 export type HighlightsContentsOptions = {
   query?: string;
+  maxCharacters?: number;
+  /** @deprecated Use maxCharacters instead */
   numSentences?: number;
+  /** @deprecated Use maxCharacters instead */
   highlightsPerUrl?: number;
 };
 


### PR DESCRIPTION
## Summary

Adds the new `maxCharacters` parameter to `HighlightsContentsOptions` type and marks `numSentences` and `highlightsPerUrl` as deprecated with JSDoc annotations. This aligns the TypeScript SDK with the API changes in `claude/update-highlights-params-Rj1d8`.

The new parameter controls the maximum total characters across all highlights per URL (default: 2000), replacing the sentence-based approach.

## Review & Testing Checklist for Human

- [ ] **Verify backend PR is merged first** - This SDK change depends on `claude/update-highlights-params-Rj1d8` being deployed. SDK release should not happen before the API supports `maxCharacters`
- [ ] **Test with actual API call** - Try `exa.searchAndContents("test", { highlights: { maxCharacters: 1000 } })` against the updated backend to confirm it works

### Notes

This is a type-only change with no runtime logic modifications. Backward compatibility is maintained - existing code using `numSentences` or `highlightsPerUrl` will continue to work.

Requested by @LiamHz

Link to Devin run: https://app.devin.ai/sessions/f82de373837142da8261ab1462c223eb