### PR TITLE
Add text content filtering options (verbosity, includeSections, excludeSections)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -153,14 +153,41 @@ export type LivecrawlOptions =
   | "preferred";
 
 /**
+ * Verbosity levels for content filtering.
+ * - compact: Most concise output, main content only (default)
+ * - standard: Balanced content with more detail
+ * - full: Complete content including all sections
+ */
+export type VerbosityOptions = "compact" | "standard" | "full";
+
+/**
+ * Section tags for semantic content filtering.
+ */
+export type SectionTag =
+  | "unspecified"
+  | "header"
+  | "navigation"
+  | "banner"
+  | "body"
+  | "sidebar"
+  | "footer"
+  | "metadata";
+
+/**
  * Options for retrieving text from page.
  * @typedef {Object} TextContentsOptions
  * @property {number} [maxCharacters] - The maximum number of characters to return.
  * @property {boolean} [includeHtmlTags] - If true, includes HTML tags in the returned text. Default: false
+ * @property {VerbosityOptions} [verbosity] - Controls verbosity level of returned content. Default: "compact". Requires livecrawl: "always".
+ * @property {SectionTag[]} [includeSections] - Only include content from these semantic sections. Requires livecrawl: "always".
+ * @property {SectionTag[]} [excludeSections] - Exclude content from these semantic sections. Requires livecrawl: "always".
  */
 export type TextContentsOptions = {
   maxCharacters?: number;
   includeHtmlTags?: boolean;
+  verbosity?: VerbosityOptions;
+  includeSections?: SectionTag[];
+  excludeSections?: SectionTag[];
 };
 
 /**


### PR DESCRIPTION
## Summary
Add new `TextContentsOptions` fields for content filtering:
- `verbosity`: "compact" (default), "standard", "full" - controls detail level
- `includeSections`: filter to specific semantic page sections
- `excludeSections`: exclude specific semantic page sections

Available section tags: `header`, `navigation`, `banner`, `body`, `sidebar`, `footer`, `metadata`

**Note**: These options require `livecrawl: "always"` to take effect.

## Example Usage
```typescript
const result = await exa.search("AI startups", {
  contents: {
    text: {
      verbosity: "standard",
      excludeSections: ["navigation", "footer", "sidebar"]
    },
    livecrawl: "always"
  }
});
```

## Test plan
- [ ] Type checking passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/120">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
