### PR TITLE
feat: add maxCharacters highlights param, deprecate legacy params

### DIFF
--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -145,7 +145,7 @@
     "searchAndContents": "const result = await exa.searchAndContents(\"AI in healthcare\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
     "findSimilar": "const result = await exa.findSimilar(\"https://www.example.com/article\", {\n  numResults: 10,\n  excludeSourceDomain: true\n});",
     "findSimilarAndContents": "const result = await exa.findSimilarAndContents(\"https://www.example.com/article\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
-    "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  text: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", numSentences: 2 }\n});",
+    "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  text: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
     "answer": "const result = await exa.answer(\"What is the capital of France?\", {\n  text: true,\n  model: \"exa\"\n});",
     "streamAnswer": "for await (const chunk of exa.streamAnswer(\"What is quantum computing?\", {\n  text: true,\n  model: \"exa\"\n})) {\n  if (chunk.content) process.stdout.write(chunk.content);\n  if (chunk.citations) console.log(\"Citations:\", chunk.citations);\n}",
     "research.create": "const task = await exa.research.create({\n  instructions: \"Research the latest AI developments\",\n  model: \"exa-research-fast\"\n});",

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
  * Options for retrieving page contents
  * @typedef {Object} ContentsOptions
  * @property {TextContentsOptions | boolean} [text] - Options for retrieving text contents.
- * @property {HighlightsContentsOptions | boolean} [highlights] - Options for retrieving highlights. NOTE: For search type "deep", only "true" is allowed. "query", "numSentences" and "highlightsPerUrl" will not be respected.
+ * @property {HighlightsContentsOptions | boolean} [highlights] - Options for retrieving highlights. NOTE: For search type "deep", only "true" is allowed. "query", "maxCharacters", "numSentences" and "highlightsPerUrl" will not be respected.
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
  * @property {number} [maxAgeHours] - Maximum age of cached content in hours. If content is older, it will be fetched fresh. Special values: 0 = always fetch fresh content, -1 = never fetch fresh (use cached content only). Example: 168 = fetch fresh for pages older than 7 days.
  * @property {boolean} [filterEmptyResults] - If true, filters out results with no contents. Default is true.
@@ -196,15 +196,18 @@ export type TextContentsOptions = {
  * to your initial query, and may vary in quantity and length.
  * @typedef {Object} HighlightsContentsOptions
  * @property {string} [query] - The query string to use for highlights search.
- * @property {number} [numSentences] - The number of sentences to return for each highlight.
- * @property {number} [highlightsPerUrl] - The number of highlights to return for each URL.
+ * @property {number} [maxCharacters] - The maximum number of characters to return for highlights.
+ * @property {number} [numSentences] - Deprecated. Use maxCharacters instead.
+ * @property {number} [highlightsPerUrl] - Deprecated. Use maxCharacters instead.
  */
 export type HighlightsContentsOptions = {
   query?: string;
+  maxCharacters?: number;
+  /** @deprecated Use maxCharacters instead */
   numSentences?: number;
+  /** @deprecated Use maxCharacters instead */
   highlightsPerUrl?: number;
 };
-
 /**
  * Options for retrieving summary from page.
  * @typedef {Object} SummaryContentsOptions

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -219,6 +219,39 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+
+  it("should handle highlights with maxCharacters option", async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: "Test Result",
+          url: "https://example.com",
+          id: "test-id",
+          highlights: ["highlight 1", "highlight 2"],
+          highlightScores: [0.9, 0.8],
+        },
+      ],
+      requestId: "req-123",
+    };
+
+    const requestSpy = vi
+      .spyOn(exa, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.searchAndContents("latest AI developments", {
+      highlights: { maxCharacters: 200, query: "key points" },
+      numResults: 2,
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith("/search", "POST", {
+      query: "latest AI developments",
+      contents: {
+        highlights: { maxCharacters: 200, query: "key points" },
+      },
+      numResults: 2,
+    });
+    expect(result).toEqual(mockResponse);
+  });
   it("should handle text and highlights together", async () => {
     const mockResponse = {
       results: [


### PR DESCRIPTION
## Summary
- Add `maxCharacters` to `HighlightsContentsOptions` type as the primary way to control highlight length
- Mark `numSentences` and `highlightsPerUrl` as `@deprecated` in JSDoc
- Update `gen_config.json` example to use `maxCharacters`
- Add unit test for the new parameter

## Test plan
- [ ] Run unit tests to verify `maxCharacters` passes through correctly
- [ ] Verify backward compat — existing `numSentences`/`highlightsPerUrl` still work
- [ ] Test against staging with `maxCharacters` parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/133">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
