### PR TITLE
Fix Zod version compatibility for SDK users

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,8 +56,15 @@
     "cross-fetch": "~4.1.0",
     "dotenv": "~16.4.7",
     "openai": "^5.0.1",
-    "zod": "^3.22.0",
     "zod-to-json-schema": "^3.20.0"
+  },
+  "peerDependencies": {
+    "zod": ">=3.24.1"
+  },
+  "peerDependenciesMeta": {
+    "zod": {
+      "optional": true
+    }
   },
   "directories": {
     "test": "test"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import fetch, { Headers } from "cross-fetch";
-import { ZodSchema } from "zod";
+import type { ZodSchema } from "zod";
 import packageJson from "../package.json";
 import { ExaError, HttpStatusCode } from "./errors";
 import { ResearchClient } from "./research/client";

--- a/src/research/client.ts
+++ b/src/research/client.ts
@@ -9,7 +9,7 @@ import {
   ResearchCreateParamsTyped,
   ResearchTyped,
 } from "./index";
-import { ZodSchema } from "zod";
+import type { ZodSchema } from "zod";
 import { isZodSchema, zodToJsonSchema } from "../zod-utils";
 import { ResearchBaseClient } from "./base";
 

--- a/src/zod-utils.ts
+++ b/src/zod-utils.ts
@@ -1,14 +1,25 @@
-import { ZodType, ZodSchema } from "zod";
 import { zodToJsonSchema as convertZodToJsonSchema } from "zod-to-json-schema";
 
-export function isZodSchema(obj: any): obj is ZodSchema<any> {
-  return obj instanceof ZodType;
+/**
+ * Duck-type check for Zod schemas. Uses structural detection instead of
+ * `instanceof` so it works across different Zod instances/versions that
+ * may coexist in the same dependency tree.
+ */
+export function isZodSchema(obj: any): boolean {
+  return (
+    obj != null &&
+    typeof obj === "object" &&
+    typeof obj.safeParse === "function" &&
+    typeof obj.parse === "function" &&
+    "_def" in obj
+  );
 }
 
 export function zodToJsonSchema(
-  schema: ZodSchema<any>
+  schema: any
 ): Record<string, unknown> {
-  return convertZodToJsonSchema(schema, {
-    $refStrategy: "none",
-  }) as Record<string, unknown>;
+  // Use type erasure via Function to avoid TS2589 "type instantiation
+  // excessively deep" errors from zod-to-json-schema's recursive types.
+  const fn = convertZodToJsonSchema as Function;
+  return fn(schema, { $refStrategy: "none" }) as Record<string, unknown>;
 }


### PR DESCRIPTION
Moves `zod` from a bundled dependency to an optional peer dependency (`>=3.24.1`) and replaces the `instanceof ZodType` check in `zod-utils.ts` with duck-type detection (`safeParse`, `parse`, `_def`). Previously, bundling zod as a regular dependency meant users ended up with two copies of zod in their node_modules — theirs and the SDK's — causing `instanceof` checks to fail silently when users passed their own Zod schemas to `outputSchema` or `summary.schema`. The duck-type approach works across any Zod instance or version, and marking the peer dep as optional means users who don't use schema features aren't forced to install zod at all. Also converts the `ZodSchema` imports in `index.ts` and `research/client.ts` to type-only imports so they're erased at compile time.