### PR TITLE
[exa-js]: deep outputSchema modes and limits (2.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ const deepResult = await exa.search("Who leads OpenAI's safety team?", {
 console.log(deepResult.output?.content);
 ```
 
+Deep `outputSchema` modes:
+- `type: "text"`: return plain text in `output.content` (optionally guided by `description`)
+- `type: "object"`: return structured JSON in `output.content`
+
+For `type: "object"`, deep search currently enforces:
+- max nesting depth: `2`
+- max total properties: `10`
+
 Deep search variants:
 - `deep`: light mode
 - `deep-reasoning`: base reasoning mode

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,41 @@ type BaseRegularSearchOptions = BaseSearchOptions & {
 export type DeepSearchType = "deep" | "deep-reasoning" | "deep-max";
 
 /**
+ * Deep search output schema mode for plain text responses.
+ */
+export type DeepTextOutputSchema = {
+  type: "text";
+  /**
+   * Optional formatting guidance for text output.
+   */
+  description?: string;
+};
+
+/**
+ * Deep search output schema mode for structured JSON object responses.
+ */
+export type DeepObjectOutputSchema = {
+  type: "object";
+  /**
+   * JSON-schema-style properties for the result object.
+   */
+  properties?: Record<string, unknown>;
+  /**
+   * Required property names.
+   */
+  required?: string[];
+};
+
+/**
+ * Deep search output schema.
+ * - `type: "text"` returns plain text in `output.content` (with optional description guidance).
+ * - `type: "object"` returns structured JSON in `output.content`.
+ *
+ * Note: For object schemas, the API enforces a maximum nesting depth of 2 and a maximum of 10 total properties.
+ */
+export type DeepOutputSchema = DeepTextOutputSchema | DeepObjectOutputSchema;
+
+/**
  * Contents options for deep search.
  * @deprecated The `context` field is deprecated. Use `highlights` or `text` instead.
  */
@@ -116,10 +151,13 @@ type DeepSearchOptions = Omit<BaseRegularSearchOptions, "contents"> & {
    */
   additionalQueries?: string[];
   /**
-   * JSON schema for structured output.
-   * If provided, the response `output.content` field will match this schema.
+   * Output schema for deep search responses.
+   * - `type: "text"` for plain text output (optionally guided by `description`)
+   * - `type: "object"` for structured JSON output
+   *
+   * Note: For object schemas, the API enforces max depth 2 and max 10 total properties.
    */
-  outputSchema?: Record<string, unknown>;
+  outputSchema?: DeepOutputSchema;
   /**
    * Options for retrieving page contents.
    */


### PR DESCRIPTION
## Summary
- add typed deep outputSchema union for /search (`type: \"text\"` or `type: \"object\"`)
- document object-schema limits (max depth 2, max 10 properties)
- bump package version from 2.6.0 to 2.6.1

## Validation
- npm run build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
