### PR TITLE
Add dashboardUrl field to Webset type

### DIFF
--- a/src/websets/openapi.ts
+++ b/src/websets/openapi.ts
@@ -1770,6 +1770,8 @@ export interface components {
        * @description The date and time the webset was created
        */
       createdAt: string;
+      /** @description The URL to view the webset in the Exa dashboard */
+      dashboardUrl: string;
       /** @description The Enrichments to apply to the Webset Items. */
       enrichments: components["schemas"]["WebsetEnrichment"][];
       /** @description The Excludes sources (existing imports or websets) that apply to all operations within this Webset. Any results found within these sources will be omitted across all search and import operations. */


### PR DESCRIPTION
## Summary

Adds the `dashboardUrl` field (type `string`, required) to the `Webset` schema in the OpenAPI types. This reflects the new field added to the public Websets API in [exa-labs/monorepo#21130](https://github.com/exa-labs/monorepo/pull/21130), which returns a URL like `https://websets.exa.ai/websets/webset_abc123` for each webset.

Without this, `dashboardUrl` is not accessible as a typed property on `Webset` objects returned by the SDK.

## Review & Testing Checklist for Human

- [ ] **Upstream OpenAPI spec sync**: `openapi.ts` is auto-generated via `npm run generate:types:websets` from the [exa-labs/openapi-spec](https://github.com/exa-labs/openapi-spec) repo. This manual edit **will be overwritten** on the next generation run. The upstream spec should also be updated to include `dashboardUrl`, or this change will be lost.
- [ ] **Required vs optional**: The field is typed as required (`string`), matching the Kronos API schema. Verify this is correct — if older API responses or edge cases could lack this field, it should be `string | undefined` to avoid runtime errors in consuming code.
- [ ] **Test mocks**: The unit test mock `Webset` objects in `test/unit/websets.test.ts` and `test/unit/websets.validation.test.ts` do not include `dashboardUrl`. These files already had pre-existing type errors (referencing a non-existent `streams` property), so this wasn't addressed here, but the mocks will need `dashboardUrl` added when those tests are fixed.
- [ ] **End-to-end verification**: Install from this branch, call `exa.websets.get(id)` or `exa.websets.create(...)`, and confirm `webset.dashboardUrl` is present and returns the expected URL.

### Notes
- Requested by: @maxwbuckley
- [Devin Session](https://app.devin.ai/sessions/b5e1b85285f4484bb58131e9057b9906)