### PR TITLE
chore(exa-js): bump version to 2.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Bump version to 2.10.1 in package.json and package-lock.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)