### PR TITLE
feat(exa-js): add deep-max search type

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Deep search variants that also support `additionalQueries`:
 - `deep-lite`
 - `deep`
 - `deep-reasoning`
+- `deep-max`
 
 ## Contents
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ type BaseRegularSearchOptions = BaseSearchOptions & {
   outputSchema?: DeepOutputSchema;
 };
 
-export type DeepSearchType = "deep-lite" | "deep" | "deep-reasoning";
+export type DeepSearchType = "deep-lite" | "deep" | "deep-reasoning" | "deep-max";
 
 /**
  * Deep search output schema mode for plain text responses.


### PR DESCRIPTION
## Summary

Adds `deep-max` to the `DeepSearchType` union, aligning the JS SDK with the API which already accepts this type. This means `deep-max` now gets proper TypeScript type support and `additionalQueries` is correctly allowed with it (via `DeepSearchOptions`).

## Review & Testing Checklist for Human
- [ ] Verify `deep-max` is live and accepted by the API (the [docs page](https://exa.ai/docs/reference/search) lists it, and Vulcan's `SearchTypeSchema` includes it)
- [ ] Confirm `deep-max` should support `additionalQueries` — by being in `DeepSearchType`, it inherits `DeepSearchOptions` which includes that field

### Notes
Companion PR for exa-py adds the same type there.

Link to Devin session: https://app.devin.ai/sessions/37d00c74a58c46af92847ccdad46699e
Requested by: @maxwbuckley
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
