### PR TITLE
[codex] Add maxPeoplePerCompany to Websets JS SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"

--- a/src/websets/openapi.ts
+++ b/src/websets/openapi.ts
@@ -807,6 +807,8 @@ export interface components {
           /** @enum {string} */
           source: WebsetExcludeSource;
         }[];
+        /** @description Optional soft cap for people searches. When set, the search will try to include at most this many matching people from the same current employer company. */
+        maxPeoplePerCompany?: number;
         /** @description Natural language search query describing what you are looking for.
          *
          *     Be specific and descriptive about your requirements, characteristics, and any constraints that help narrow down the results.
@@ -863,6 +865,8 @@ export interface components {
       metadata?: {
         [key: string]: string;
       };
+      /** @description Optional soft cap for people searches. When set, the search will try to include at most this many matching people from the same current employer company. */
+      maxPeoplePerCompany?: number;
       /** @description Natural language search query describing what you are looking for.
        *
        *     Be specific and descriptive about your requirements, characteristics, and any constraints that help narrow down the results.
@@ -2141,6 +2145,8 @@ export interface components {
       }[];
       /** @description The unique identifier for the search */
       id: string;
+      /** @description The soft cap requested for matching people from the same current employer company, or null when no cap was requested. */
+      maxPeoplePerCompany: number | null;
       /**
        * @description Set of key-value pairs you want to associate with this object.
        * @default {}

--- a/test/unit/websets.test.ts
+++ b/test/unit/websets.test.ts
@@ -59,6 +59,8 @@ describe("Websets API", () => {
       search: {
         query: "Test query",
         count: 10,
+        entity: { type: "person" as const },
+        maxPeoplePerCompany: 2,
       },
     };
     const result = await exa.websets.create(createParams);
@@ -398,6 +400,7 @@ describe("Websets API", () => {
       entity: { type: "company" },
       metadata: {},
       exclude: [],
+      maxPeoplePerCompany: 2,
       recall: null,
       scope: [],
     };
@@ -411,6 +414,8 @@ describe("Websets API", () => {
       query: "Test search",
       count: 10,
       behavior: WebsetSearchBehavior.override,
+      entity: { type: "person" as const },
+      maxPeoplePerCompany: 2,
     };
     const result = await exa.websets.searches.create("ws_123456", searchParams);
 


### PR DESCRIPTION
## Summary

Expose the new Websets `maxPeoplePerCompany` parameter in the JS SDK types.

- Adds `maxPeoplePerCompany` to create Webset search parameters.
- Adds `maxPeoplePerCompany` to create search parameters.
- Adds `maxPeoplePerCompany` to Webset search responses.
- Bumps the SDK patch version to `2.11.1`.

## Validation

- `npx vitest run test/unit/websets.test.ts`
- `npm run build-fast`
- `git diff --check`