### PR TITLE
[codex] Bump exa-js version to 2.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "2.11.1",
+  "version": "2.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "2.11.1",
+      "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "2.11.1",
+  "version": "2.12.1",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Bump the JS SDK package version to `2.12.1` so it matches the Python SDK version.

- Updates `package.json` from `2.11.1` to `2.12.1`.
- Updates the root package version entries in `package-lock.json`.

## Validation

- `npm install --package-lock-only`
- `git diff --check`
- `npm run build-fast`