### PR TITLE
Add fullText contents option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Deep search variants that also support `additionalQueries`:
 
 ## Contents
 
-Get clean highlight-backed text, full text, highlights, or summaries from any URL.
+Get clean text, full text, highlights, or summaries from any URL. Add `query` inside `text` to return focused excerpts instead of truncated full page text.
 
 ```ts
 const { results } = await exa.getContents(["https://docs.exa.ai"], {
-  fullText: true,
+  text: true,
   highlights: true,
   summary: true,
 });

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ Deep search variants that also support `additionalQueries`:
 
 ## Contents
 
-Get clean text, highlights, or summaries from any URL.
+Get clean highlight-backed text, full text, highlights, or summaries from any URL.
 
 ```ts
 const { results } = await exa.getContents(["https://docs.exa.ai"], {
-  text: true,
+  fullText: true,
   highlights: true,
   summary: true,
 });

--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -54,7 +54,8 @@
       {"name": "additionalQueries", "type": "string[]", "description": "Alternative query formulations for deep search. Max 5 queries. Only for type: \"deep\"."}
     ],
     "ContentsOptions": [
-      {"name": "text", "type": "TextContentsOptions | true", "description": "Options for retrieving text contents."},
+      {"name": "text", "type": "TextContentsOptions | true", "description": "Options for retrieving highlight-backed text on search and getContents, or full page text on findSimilar."},
+      {"name": "fullText", "type": "TextContentsOptions | true", "description": "Options for retrieving full page text on search and getContents."},
       {"name": "highlights", "type": "HighlightsContentsOptions | true", "description": "Options for retrieving highlights."},
       {"name": "summary", "type": "SummaryContentsOptions | true", "description": "Options for retrieving summary."},
       {"name": "maxAgeHours", "type": "number", "description": "Maximum age of cached content in hours. If content is older, it will be fetched fresh. Special values: 0 = always fetch fresh content, -1 = never fetch fresh (cache only). Example: 168 = fetch fresh for pages older than 7 days."},
@@ -73,7 +74,8 @@
       {"name": "score", "type": "number", "description": "Similarity score between the query/url and the result."},
       {"name": "image", "type": "string", "description": "A representative image for the content, if any."},
       {"name": "favicon", "type": "string", "description": "A favicon for the site, if any."},
-      {"name": "text", "type": "string", "description": "The text content of the page (if text option enabled)."},
+      {"name": "text", "type": "string", "description": "Highlight-backed text on search and getContents, or full page text on findSimilar (if text option enabled)."},
+      {"name": "fullText", "type": "string", "description": "Full page text content (if fullText option enabled)."},
       {"name": "highlights", "type": "string[]", "description": "Highlighted text snippets (if highlights option enabled)."},
       {"name": "highlightScores", "type": "number[]", "description": "Scores for each highlight."},
       {"name": "summary", "type": "string", "description": "Summary of the content (if summary option enabled)."},
@@ -145,7 +147,7 @@
     "searchAndContents": "const result = await exa.searchAndContents(\"AI in healthcare\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
     "findSimilar": "const result = await exa.findSimilar(\"https://www.example.com/article\", {\n  numResults: 10,\n  excludeSourceDomain: true\n});",
     "findSimilarAndContents": "const result = await exa.findSimilarAndContents(\"https://www.example.com/article\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
-    "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  text: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
+    "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  fullText: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
     "answer": "const result = await exa.answer(\"What is the capital of France?\", {\n  text: true,\n  model: \"exa\"\n});",
     "streamAnswer": "for await (const chunk of exa.streamAnswer(\"What is quantum computing?\", {\n  text: true,\n  model: \"exa\"\n})) {\n  if (chunk.content) process.stdout.write(chunk.content);\n  if (chunk.citations) console.log(\"Citations:\", chunk.citations);\n}",
     "research.create": "const task = await exa.research.create({\n  instructions: \"Research the latest AI developments\",\n  model: \"exa-research-fast\"\n});",
@@ -221,7 +223,7 @@
           "url": "https://example.com/article",
           "id": "https://example.com/article",
           "title": "Example Article",
-          "text": "The full text content of the article..."
+          "fullText": "The full text content of the article..."
         }
       ]
     },

--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -54,7 +54,7 @@
       {"name": "additionalQueries", "type": "string[]", "description": "Alternative query formulations for deep search. Max 5 queries. Only for type: \"deep\"."}
     ],
     "ContentsOptions": [
-      {"name": "text", "type": "TextContentsOptions | true", "description": "Options for retrieving highlight-backed text on search and getContents, or full page text on findSimilar."},
+      {"name": "text", "type": "TextContentsOptions | true", "description": "Options for retrieving highlight-backed text on search, truncated full page text on getContents unless query is set, or full page text on findSimilar."},
       {"name": "fullText", "type": "TextContentsOptions | true", "description": "Options for retrieving full page text on search and getContents."},
       {"name": "highlights", "type": "HighlightsContentsOptions | true", "description": "Options for retrieving highlights."},
       {"name": "summary", "type": "SummaryContentsOptions | true", "description": "Options for retrieving summary."},
@@ -74,7 +74,7 @@
       {"name": "score", "type": "number", "description": "Similarity score between the query/url and the result."},
       {"name": "image", "type": "string", "description": "A representative image for the content, if any."},
       {"name": "favicon", "type": "string", "description": "A favicon for the site, if any."},
-      {"name": "text", "type": "string", "description": "Highlight-backed text on search and getContents, or full page text on findSimilar (if text option enabled)."},
+      {"name": "text", "type": "string", "description": "Highlight-backed text on search, truncated full page text on getContents unless query is set, or full page text on findSimilar (if text option enabled)."},
       {"name": "fullText", "type": "string", "description": "Full page text content (if fullText option enabled)."},
       {"name": "highlights", "type": "string[]", "description": "Highlighted text snippets (if highlights option enabled)."},
       {"name": "highlightScores", "type": "number[]", "description": "Scores for each highlight."},
@@ -147,7 +147,7 @@
     "searchAndContents": "const result = await exa.searchAndContents(\"AI in healthcare\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
     "findSimilar": "const result = await exa.findSimilar(\"https://www.example.com/article\", {\n  numResults: 10,\n  excludeSourceDomain: true\n});",
     "findSimilarAndContents": "const result = await exa.findSimilarAndContents(\"https://www.example.com/article\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
-    "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  fullText: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
+    "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  text: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
     "answer": "const result = await exa.answer(\"What is the capital of France?\", {\n  text: true,\n  model: \"exa\"\n});",
     "streamAnswer": "for await (const chunk of exa.streamAnswer(\"What is quantum computing?\", {\n  text: true,\n  model: \"exa\"\n})) {\n  if (chunk.content) process.stdout.write(chunk.content);\n  if (chunk.citations) console.log(\"Citations:\", chunk.citations);\n}",
     "research.create": "const task = await exa.research.create({\n  instructions: \"Research the latest AI developments\",\n  model: \"exa-research-fast\"\n});",
@@ -223,7 +223,7 @@
           "url": "https://example.com/article",
           "id": "https://example.com/article",
           "title": "Example Article",
-          "fullText": "The full text content of the article..."
+          "text": "The text content of the article..."
         }
       ]
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
 /**
  * Options for retrieving page contents
  * @typedef {Object} ContentsOptions
- * @property {TextContentsOptions | boolean} [text] - Options for retrieving text contents.
+ * @property {TextContentsOptions | boolean} [text] - Options for retrieving highlight-backed text on search and getContents, or full page text on findSimilar.
+ * @property {TextContentsOptions | boolean} [fullText] - Options for retrieving full page text on search and getContents.
  * @property {HighlightsContentsOptions | boolean} [highlights] - Options for retrieving highlights.
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
  * @property {number} [maxAgeHours] - Maximum age of cached content in hours. If content is older, it will be fetched fresh. Special values: 0 = always fetch fresh content, -1 = never fetch fresh (use cached content only). Example: 168 = fetch fresh for pages older than 7 days.
@@ -29,6 +30,7 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
  */
 export type ContentsOptions = {
   text?: TextContentsOptions | true;
+  fullText?: TextContentsOptions | true;
   highlights?: HighlightsContentsOptions | true;
   summary?: SummaryContentsOptions | true;
   livecrawl?: LivecrawlOptions;
@@ -291,9 +293,15 @@ export type ContextOptions = {
 
 /**
  * @typedef {Object} TextResponse
- * @property {string} text - Text from page
+ * @property {string} text - Highlight-backed text from the page on search and getContents, or full page text on findSimilar.
  */
 export type TextResponse = { text: string };
+
+/**
+ * @typedef {Object} FullTextResponse
+ * @property {string} fullText - Full page text from the page.
+ */
+export type FullTextResponse = { fullText: string };
 
 /**
  * @typedef {Object} HighlightsResponse
@@ -338,6 +346,7 @@ export type Default<T extends {}, U> = [keyof T] extends [never] ? U : T;
  */
 export type ContentsResultComponent<T extends ContentsOptions> =
   (T["text"] extends object | true ? TextResponse : {}) &
+    (T["fullText"] extends object | true ? FullTextResponse : {}) &
     (T["highlights"] extends object | true ? HighlightsResponse : {}) &
     (T["summary"] extends object | true ? SummaryResponse : {}) &
     (T["subpages"] extends number ? SubpagesResponse<T> : {}) &
@@ -675,6 +684,7 @@ export class Exa {
   } {
     const {
       text,
+      fullText,
       highlights,
       summary,
       subpages,
@@ -689,9 +699,10 @@ export class Exa {
 
     const contentsOptions: ContentsOptions = {};
 
-    // Default: if none of text, summary, or highlights is provided, we retrieve text
+    // Default: if none of text, fullText, summary, or highlights is provided, we retrieve text
     if (
       text === undefined &&
+      fullText === undefined &&
       summary === undefined &&
       highlights === undefined &&
       extras === undefined
@@ -700,6 +711,7 @@ export class Exa {
     }
 
     if (text !== undefined) contentsOptions.text = text;
+    if (fullText !== undefined) contentsOptions.fullText = fullText;
     if (highlights !== undefined) contentsOptions.highlights = highlights;
     if (summary !== undefined) {
       // Handle zod schema conversion for summary

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
 /**
  * Options for retrieving page contents
  * @typedef {Object} ContentsOptions
- * @property {TextContentsOptions | boolean} [text] - Options for retrieving highlight-backed text on search and getContents, or full page text on findSimilar.
+ * @property {TextContentsOptions | boolean} [text] - Options for retrieving highlight-backed text on search, truncated full page text on getContents unless query is set, or full page text on findSimilar.
  * @property {TextContentsOptions | boolean} [fullText] - Options for retrieving full page text on search and getContents.
  * @property {HighlightsContentsOptions | boolean} [highlights] - Options for retrieving highlights.
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
@@ -232,6 +232,7 @@ export type SectionTag =
 /**
  * Options for retrieving text from page.
  * @typedef {Object} TextContentsOptions
+ * @property {string} [query] - Optional guiding query. On getContents, setting query makes text return focused excerpts instead of truncated full page text.
  * @property {number} [maxCharacters] - The maximum number of characters to return.
  * @property {boolean} [includeHtmlTags] - If true, includes HTML tags in the returned text. Default: false
  * @property {VerbosityOptions} [verbosity] - Controls verbosity level of returned content. Default: "compact". Requires maxAgeHours: 0.
@@ -239,6 +240,7 @@ export type SectionTag =
  * @property {SectionTag[]} [excludeSections] - Exclude content from these semantic sections. Requires maxAgeHours: 0.
  */
 export type TextContentsOptions = {
+  query?: string;
   maxCharacters?: number;
   includeHtmlTags?: boolean;
   verbosity?: VerbosityOptions;
@@ -293,7 +295,7 @@ export type ContextOptions = {
 
 /**
  * @typedef {Object} TextResponse
- * @property {string} text - Highlight-backed text from the page on search and getContents, or full page text on findSimilar.
+ * @property {string} text - Highlight-backed text from the page on search, truncated full page text on getContents unless query is set, or full page text on findSimilar.
  */
 export type TextResponse = { text: string };
 

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -397,6 +397,34 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("should pass query-guided text through getContents", async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: "Test Result",
+          url: "https://example.com",
+          id: "test-id",
+          text: "Focused text excerpt",
+        },
+      ],
+      requestId: "req-123",
+    };
+
+    const requestSpy = vi
+      .spyOn(exa, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.getContents(["https://example.com"], {
+      text: { query: "when did they graduate", maxCharacters: 1000 },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith("/contents", "POST", {
+      urls: ["https://example.com"],
+      text: { query: "when did they graduate", maxCharacters: 1000 },
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
   it("should default to text with maxCharacters when no content options provided", async () => {
     const mockResponse = {
       results: [

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -308,6 +308,38 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("should handle fullText with searchAndContents", async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: "Test Result",
+          url: "https://example.com",
+          id: "test-id",
+          fullText: "Full page text content",
+        },
+      ],
+      requestId: "req-123",
+    };
+
+    const requestSpy = vi
+      .spyOn(exa, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.searchAndContents("latest AI developments", {
+      fullText: { maxCharacters: 1000 },
+      numResults: 2,
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith("/search", "POST", {
+      query: "latest AI developments",
+      contents: {
+        fullText: { maxCharacters: 1000 },
+      },
+      numResults: 2,
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
   it("should handle highlights via search contents option", async () => {
     const mockResponse = {
       results: [
@@ -333,6 +365,34 @@ describe("Search API", () => {
     expect(requestSpy).toHaveBeenCalledWith("/search", "POST", {
       query: "test query",
       contents: { highlights: { numSentences: 2 } },
+    });
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("should pass fullText through getContents", async () => {
+    const mockResponse = {
+      results: [
+        {
+          title: "Test Result",
+          url: "https://example.com",
+          id: "test-id",
+          fullText: "Full page text content",
+        },
+      ],
+      requestId: "req-123",
+    };
+
+    const requestSpy = vi
+      .spyOn(exa, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.getContents(["https://example.com"], {
+      fullText: { maxCharacters: 1000 },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith("/contents", "POST", {
+      urls: ["https://example.com"],
+      fullText: { maxCharacters: 1000 },
     });
     expect(result).toEqual(mockResponse);
   });


### PR DESCRIPTION
## Summary
- add fullText to ContentsOptions and typed result composition
- keep text documented as highlight-backed for search/getContents while findSimilar remains full-page text
- update README/generated-doc config examples and request-construction tests

## Testing
- npm run test:unit -- test/unit/search.test.ts
- git diff --check
- npm run typecheck (fails on existing examples/websets/generated type drift and missing ts-morph; no new fullText diagnostics observed)