### PR TITLE
Mark deprecated APIs clearly

### DIFF
--- a/examples/schema_summary_example.ts
+++ b/examples/schema_summary_example.ts
@@ -1,11 +1,11 @@
-import Exa, { JSONSchema } from "../src/index";
+import Exa from "../src/index";
 
 const exa = new Exa(process.env.EXA_API_KEY);
 
 async function runSchemaSummaryExample() {
   try {
     // Define a JSON schema for structured company information.
-    const companySchema: JSONSchema = {
+    const companySchema: Record<string, unknown> = {
       $schema: "http://json-schema.org/draft-07/schema#",
       title: "Company Information",
       type: "object",

--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -62,7 +62,7 @@
       {"name": "subpages", "type": "number", "description": "Number of subpages to return for each result."},
       {"name": "subpageTarget", "type": "string | string[]", "description": "Text used to match/rank subpages in the returned list."},
       {"name": "extras", "type": "ExtrasOptions", "description": "Miscellaneous data derived from results."},
-      {"name": "context", "type": "ContextOptions | true", "description": "Deprecated. Use `highlights` or `text` instead. Will be removed in a future version."}
+      {"name": "context", "type": "ContextOptions | true", "description": "DEPRECATED: Use `text` or `highlights` instead. Will be removed in a future version."}
     ],
     "SearchResult": [
       {"name": "title", "type": "string | null", "description": "The title of the search result."},
@@ -82,7 +82,7 @@
     "SearchResponse": [
       {"name": "results", "type": "SearchResult<T>[]", "description": "The list of search results."},
       {"name": "requestId", "type": "string", "description": "The request ID for the search."},
-      {"name": "context", "type": "string", "description": "Deprecated. The combined context string. Use `highlights` or `text` on individual results instead."},
+      {"name": "context", "type": "string", "description": "DEPRECATED: Use `text` or `highlights` on individual results instead. Will be removed in a future version."},
       {"name": "autoDate", "type": "string", "description": "The autoprompt date, if applicable."},
       {"name": "statuses", "type": "Status[]", "description": "Status information for each result."},
       {"name": "costDollars", "type": "CostDollars", "description": "The cost breakdown for this request."}
@@ -134,17 +134,17 @@
   },
     "method_notes": {
       "search": "The `options.type` parameter accepts: `\"auto\"` (default), `\"fast\"`, `\"deep\"`, or `\"neural\"`. See [RegularSearchOptions](#regularsearchoptions) for all available options.",
-      "searchAndContents": "The `options.type` parameter accepts: `\"auto\"` (default), `\"fast\"`, `\"deep\"`, or `\"neural\"`. See [RegularSearchOptions](#regularsearchoptions) for all available options.",
+      "searchAndContents": "DEPRECATED: Use `search()` instead. Pass content options under `contents`, for example `exa.search(query, { contents: { text: true } })`. Will be removed in a future version.",
       "findSimilar": "See [FindSimilarOptions](#findsimilaroptions) for all available options including `excludeSourceDomain`.",
-      "findSimilarAndContents": "See [FindSimilarOptions](#findsimilaroptions) for all available options including `excludeSourceDomain`.",
+      "findSimilarAndContents": "DEPRECATED: Use `findSimilar()` instead. Pass content options under `contents`, for example `exa.findSimilar(url, { contents: { text: true } })`. Will be removed in a future version.",
       "research.get": "When called with `stream: true`, returns an `AsyncGenerator<ResearchStreamEvent>` for real-time SSE updates instead of a `Promise<Research>`.",
       "research.pollUntilFinished": "Options include `pollInterval` (default 1000ms), `timeoutMs` (default 10 minutes), and `events` (boolean to include event log)."
     },
   "input_examples": {
     "search": "const result = await exa.search(\"hottest AI startups\", {\n  numResults: 10\n});",
-    "searchAndContents": "const result = await exa.searchAndContents(\"AI in healthcare\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
+    "searchAndContents": "// DEPRECATED: use exa.search with contents instead.\nconst result = await exa.search(\"AI in healthcare\", {\n  contents: {\n    text: true,\n    highlights: true\n  },\n  numResults: 5\n});",
     "findSimilar": "const result = await exa.findSimilar(\"https://www.example.com/article\", {\n  numResults: 10,\n  excludeSourceDomain: true\n});",
-    "findSimilarAndContents": "const result = await exa.findSimilarAndContents(\"https://www.example.com/article\", {\n  text: true,\n  highlights: true,\n  numResults: 5\n});",
+    "findSimilarAndContents": "// DEPRECATED: use exa.findSimilar with contents instead.\nconst result = await exa.findSimilar(\"https://www.example.com/article\", {\n  contents: {\n    text: true,\n    highlights: true\n  },\n  numResults: 5\n});",
     "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  text: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
     "answer": "const result = await exa.answer(\"What is the capital of France?\", {\n  text: true,\n  model: \"exa\"\n});",
     "streamAnswer": "for await (const chunk of exa.streamAnswer(\"What is quantum computing?\", {\n  text: true,\n  model: \"exa\"\n})) {\n  if (chunk.content) process.stdout.write(chunk.content);\n  if (chunk.citations) console.log(\"Citations:\", chunk.citations);\n}",

--- a/scripts/gen_config.json
+++ b/scripts/gen_config.json
@@ -135,16 +135,16 @@
     "method_notes": {
       "search": "The `options.type` parameter accepts: `\"auto\"` (default), `\"fast\"`, `\"deep\"`, or `\"neural\"`. See [RegularSearchOptions](#regularsearchoptions) for all available options.",
       "searchAndContents": "DEPRECATED: Use `search()` instead. Pass content options under `contents`, for example `exa.search(query, { contents: { text: true } })`. Will be removed in a future version.",
-      "findSimilar": "See [FindSimilarOptions](#findsimilaroptions) for all available options including `excludeSourceDomain`.",
-      "findSimilarAndContents": "DEPRECATED: Use `findSimilar()` instead. Pass content options under `contents`, for example `exa.findSimilar(url, { contents: { text: true } })`. Will be removed in a future version.",
+      "findSimilar": "DEPRECATED: Use `search()` for new discovery flows. There is no direct replacement for URL-based similarity. Will be removed in a future version.",
+      "findSimilarAndContents": "DEPRECATED: Use `search()` instead for new discovery flows. Pass content options under `contents`, for example `exa.search(query, { contents: { text: true } })`. There is no direct replacement for URL-based similarity. Will be removed in a future version.",
       "research.get": "When called with `stream: true`, returns an `AsyncGenerator<ResearchStreamEvent>` for real-time SSE updates instead of a `Promise<Research>`.",
       "research.pollUntilFinished": "Options include `pollInterval` (default 1000ms), `timeoutMs` (default 10 minutes), and `events` (boolean to include event log)."
     },
   "input_examples": {
     "search": "const result = await exa.search(\"hottest AI startups\", {\n  numResults: 10\n});",
     "searchAndContents": "// DEPRECATED: use exa.search with contents instead.\nconst result = await exa.search(\"AI in healthcare\", {\n  contents: {\n    text: true,\n    highlights: true\n  },\n  numResults: 5\n});",
-    "findSimilar": "const result = await exa.findSimilar(\"https://www.example.com/article\", {\n  numResults: 10,\n  excludeSourceDomain: true\n});",
-    "findSimilarAndContents": "// DEPRECATED: use exa.findSimilar with contents instead.\nconst result = await exa.findSimilar(\"https://www.example.com/article\", {\n  contents: {\n    text: true,\n    highlights: true\n  },\n  numResults: 5\n});",
+    "findSimilar": "// DEPRECATED: use exa.search for new discovery flows instead.\nconst result = await exa.search(\"articles about AI and machine learning\", {\n  numResults: 10\n});",
+    "findSimilarAndContents": "// DEPRECATED: use exa.search with contents for new discovery flows instead.\nconst result = await exa.search(\"articles about AI and machine learning\", {\n  contents: {\n    text: true,\n    highlights: true\n  },\n  numResults: 5\n});",
     "getContents": "const result = await exa.getContents([\n  \"https://www.example.com/article1\",\n  \"https://www.example.com/article2\"\n], {\n  text: { maxCharacters: 1000 },\n  highlights: { query: \"AI\", maxCharacters: 200 }\n});",
     "answer": "const result = await exa.answer(\"What is the capital of France?\", {\n  text: true,\n  model: \"exa\"\n});",
     "streamAnswer": "for await (const chunk of exa.streamAnswer(\"What is quantum computing?\", {\n  text: true,\n  model: \"exa\"\n})) {\n  if (chunk.content) process.stdout.write(chunk.content);\n  if (chunk.citations) console.log(\"Citations:\", chunk.citations);\n}",

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,6 +191,9 @@ type NonDeepSearchOptions = BaseRegularSearchOptions & {
 export type RegularSearchOptions = DeepSearchOptions | NonDeepSearchOptions;
 
 /**
+ * DEPRECATED: Used only by deprecated `findSimilar()` APIs. Use `search()` and `RegularSearchOptions` for new search flows. Will be removed in a future version.
+ * @deprecated Use `search()` and `RegularSearchOptions` for new search flows. There is no direct replacement for URL-based similarity.
+ *
  * Options for finding similar links.
  * @typedef {Object} FindSimilarOptions
  * @property {boolean} [excludeSourceDomain] - If true, excludes links from the base domain of the input.
@@ -1055,6 +1058,9 @@ export class Exa {
   }
 
   /**
+   * DEPRECATED: Use `search()` for new discovery flows. There is no direct replacement for URL-based similarity.
+   * @deprecated Use `search()` for new discovery flows. This legacy URL-similarity method will be removed in a future version.
+   *
    * Finds similar links to the provided URL.
    * By default, returns text contents. Use contents: false to opt-out.
    *
@@ -1065,6 +1071,9 @@ export class Exa {
     url: string
   ): Promise<SearchResponse<{ text: { maxCharacters: 10_000 } }>>;
   /**
+   * DEPRECATED: Use `search()` for new discovery flows. There is no direct replacement for URL-based similarity.
+   * @deprecated Use `search()` for new discovery flows. This legacy URL-similarity method will be removed in a future version.
+   *
    * Finds similar links to the provided URL without contents.
    *
    * @param {string} url - The URL for which to find similar links.
@@ -1076,6 +1085,9 @@ export class Exa {
     options: FindSimilarOptions & { contents: false | null | undefined }
   ): Promise<SearchResponse<{}>>;
   /**
+   * DEPRECATED: Use `search()` with `contents` for new discovery flows. There is no direct replacement for URL-based similarity.
+   * @deprecated Use `search()` with `contents` for new discovery flows. This legacy URL-similarity method will be removed in a future version.
+   *
    * Finds similar links to the provided URL with specific contents.
    *
    * @param {string} url - The URL for which to find similar links.
@@ -1087,6 +1099,9 @@ export class Exa {
     options: FindSimilarOptions & { contents: T }
   ): Promise<SearchResponse<T>>;
   /**
+   * DEPRECATED: Use `search()` for new discovery flows. There is no direct replacement for URL-based similarity.
+   * @deprecated Use `search()` for new discovery flows. This legacy URL-similarity method will be removed in a future version.
+   *
    * Finds similar links to the provided URL.
    * When no contents option is specified, returns text contents by default.
    *
@@ -1102,6 +1117,7 @@ export class Exa {
     url: string,
     options?: FindSimilarOptions & { contents?: T | false | null | undefined }
   ): Promise<SearchResponse<T | { text: { maxCharacters: 10_000 } } | {}>> {
+    // DEPRECATED METHOD: preserve legacy URL-similarity endpoint for compatibility.
     if (options === undefined || !("contents" in options)) {
       // No options or no contents property → default to text contents
       return await this.request("/findSimilar", "POST", {
@@ -1129,13 +1145,13 @@ export class Exa {
   }
 
   /**
-   * DEPRECATED: Use `findSimilar()` instead. This legacy wrapper will be removed in a future version.
-   * @deprecated Use `findSimilar()` instead. The findSimilar method now returns text contents by default.
+   * DEPRECATED: Use `search()` for new discovery flows instead. This legacy wrapper will be removed in a future version.
+   * @deprecated Use `search()` for new discovery flows instead. There is no direct replacement for URL-based similarity.
    *
    * Migration examples:
-   * - `findSimilarAndContents(url)` → `findSimilar(url)`
-   * - `findSimilarAndContents(url, { text: true })` → `findSimilar(url, { contents: { text: true } })`
-   * - `findSimilarAndContents(url, { summary: true })` → `findSimilar(url, { contents: { summary: true } })`
+   * - `findSimilarAndContents(url)` → `search(query)`
+   * - `findSimilarAndContents(url, { text: true })` → `search(query, { contents: { text: true } })`
+   * - `findSimilarAndContents(url, { summary: true })` → `search(query, { contents: { summary: true } })`
    *
    * Compatibility wrapper for the legacy top-level contents options shape.
    * @param {string} url - The URL for which to find similar links.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ const DEFAULT_MAX_CHARACTERS = 10_000;
  * @property {TextContentsOptions | boolean} [text] - Options for retrieving text contents.
  * @property {HighlightsContentsOptions | boolean} [highlights] - Options for retrieving highlights.
  * @property {SummaryContentsOptions | boolean} [summary] - Options for retrieving summary.
+ * @property {ContextOptions | boolean} [context] - DEPRECATED: Use `text` or `highlights` instead. Will be removed in a future version.
  * @property {number} [maxAgeHours] - Maximum age of cached content in hours. If content is older, it will be fetched fresh. Special values: 0 = always fetch fresh content, -1 = never fetch fresh (use cached content only). Example: 168 = fetch fresh for pages older than 7 days.
  * @property {boolean} [filterEmptyResults] - If true, filters out results with no contents. Default is true.
  * @property {number} [subpages] - The number of subpages to return for each result, where each subpage is derived from an internal link for the result.
@@ -32,7 +33,10 @@ export type ContentsOptions = {
   highlights?: HighlightsContentsOptions | true;
   summary?: SummaryContentsOptions | true;
   livecrawl?: LivecrawlOptions;
-  /** @deprecated Use `highlights` or `text` instead. Will be removed in a future version. */
+  /**
+   * DEPRECATED: Use `text` or `highlights` instead. Will be removed in a future version.
+   * @deprecated Use `text` or `highlights` instead. This legacy `context` field will be removed in a future version.
+   */
   context?: ContextOptions | true;
   livecrawlTimeout?: number;
   maxAgeHours?: number;
@@ -147,11 +151,13 @@ export type DeepOutputSchema = DeepTextOutputSchema | DeepObjectOutputSchema;
 
 /**
  * Contents options for deep search.
- * @deprecated The `context` field is deprecated. Use `highlights` or `text` instead.
  */
 type DeepContentsOptions = Omit<ContentsOptions, "context"> & {
-  /** @deprecated Use `highlights` or `text` instead. Will be removed in a future version. */
-  context?: Omit<ContextOptions, never> | true;
+  /**
+   * DEPRECATED: Use `text` or `highlights` instead. Will be removed in a future version.
+   * @deprecated Use `text` or `highlights` instead. This legacy `context` field will be removed in a future version.
+   */
+  context?: ContextOptions | true;
 };
 
 /**
@@ -250,22 +256,28 @@ export type TextContentsOptions = {
  * @typedef {Object} HighlightsContentsOptions
  * @property {string} [query] - The query string to use for highlights search.
  * @property {number} [maxCharacters] - The maximum number of characters to return for highlights.
- * @property {number} [numSentences] - Deprecated. Use maxCharacters instead.
- * @property {number} [highlightsPerUrl] - Deprecated. Use maxCharacters instead.
+ * @property {number} [numSentences] - DEPRECATED: Use maxCharacters instead.
+ * @property {number} [highlightsPerUrl] - DEPRECATED: Use maxCharacters instead.
  */
 export type HighlightsContentsOptions = {
   query?: string;
   maxCharacters?: number;
-  /** @deprecated Use maxCharacters instead */
+  /**
+   * DEPRECATED: Use `maxCharacters` instead. Will be removed in a future version.
+   * @deprecated Use `maxCharacters` instead. This legacy sizing field will be removed in a future version.
+   */
   numSentences?: number;
-  /** @deprecated Use maxCharacters instead */
+  /**
+   * DEPRECATED: Use `maxCharacters` instead. Will be removed in a future version.
+   * @deprecated Use `maxCharacters` instead. This legacy sizing field will be removed in a future version.
+   */
   highlightsPerUrl?: number;
 };
 /**
  * Options for retrieving summary from page.
  * @typedef {Object} SummaryContentsOptions
  * @property {string} [query] - The query string to use for summary generation.
- * @property {JSONSchema} [schema] - JSON schema for structured output from summary.
+ * @property {Record<string, unknown> | ZodSchema} [schema] - JSON schema for structured output from summary.
  */
 export type SummaryContentsOptions = {
   query?: string;
@@ -273,12 +285,14 @@ export type SummaryContentsOptions = {
 };
 
 /**
- * @deprecated Use Record<string, unknown> instead.
+ * DEPRECATED: Use `Record<string, unknown>` instead. Will be removed in a future version.
+ * @deprecated Use `Record<string, unknown>` instead.
  */
 export type JSONSchema = Record<string, unknown>;
 
 /**
- * @deprecated Use `highlights` or `text` instead. The `context` option is deprecated and will be removed in a future version.
+ * DEPRECATED: Use `text` or `highlights` instead. Will be removed in a future version.
+ * @deprecated Use `text` or `highlights` instead. The `context` option will be removed in a future version.
  *
  * Options for retrieving the context from a list of search results. The context is a string
  * representation of all the search results.
@@ -523,7 +537,7 @@ export type DeepSearchOutput = {
  * Represents a search response object.
  * @typedef {Object} SearchResponse
  * @property {Result[]} results - The list of search results.
- * @property {string} [context] - Deprecated. The context for the search.
+ * @property {string} [context] - DEPRECATED: Use `text` or `highlights` on individual results instead. Will be removed in a future version.
  * @property {DeepSearchOutput} [output] - Search synthesized output object returned when `outputSchema` is provided.
  * @property {string} [autoDate] - The autoprompt date, if applicable.
  * @property {string} requestId - The request ID for the search.
@@ -533,7 +547,10 @@ export type DeepSearchOutput = {
  */
 export type SearchResponse<T extends ContentsOptions> = {
   results: SearchResult<T>[];
-  /** @deprecated Use `highlights` or `text` on individual results instead. Will be removed in a future version. */
+  /**
+   * DEPRECATED: Use `text` or `highlights` on individual results instead. Will be removed in a future version.
+   * @deprecated Use `text` or `highlights` on individual results instead. This legacy `context` field will be removed in a future version.
+   */
   context?: string;
   output?: DeepSearchOutput;
   autoDate?: string;
@@ -683,6 +700,7 @@ export class Exa {
       livecrawl,
       livecrawlTimeout,
       maxAgeHours,
+      // DEPRECATED FIELD: preserve legacy `context` only for backward compatibility.
       context,
       ...rest
     } = options;
@@ -726,6 +744,7 @@ export class Exa {
     if (livecrawlTimeout !== undefined)
       contentsOptions.livecrawlTimeout = livecrawlTimeout;
     if (maxAgeHours !== undefined) contentsOptions.maxAgeHours = maxAgeHours;
+    // DEPRECATED FIELD: pass through only so existing callers do not break.
     if (context !== undefined) contentsOptions.context = context;
 
     return {
@@ -1000,6 +1019,7 @@ export class Exa {
   }
 
   /**
+   * DEPRECATED: Use `search()` instead. This legacy wrapper will be removed in a future version.
    * @deprecated Use `search()` instead. The search method now returns text contents by default.
    *
    * Migration examples:
@@ -1007,7 +1027,7 @@ export class Exa {
    * - `searchAndContents(query, { text: true })` → `search(query, { contents: { text: true } })`
    * - `searchAndContents(query, { summary: true })` → `search(query, { contents: { summary: true } })`
    *
-   * Performs a search with an Exa prompt-engineered query and returns the contents of the documents.
+   * Compatibility wrapper for the legacy top-level contents options shape.
    *
    * @param {string} query - The query string.
    * @param {RegularSearchOptions & T} [options] - Additional search + contents options
@@ -1109,6 +1129,7 @@ export class Exa {
   }
 
   /**
+   * DEPRECATED: Use `findSimilar()` instead. This legacy wrapper will be removed in a future version.
    * @deprecated Use `findSimilar()` instead. The findSimilar method now returns text contents by default.
    *
    * Migration examples:
@@ -1116,7 +1137,7 @@ export class Exa {
    * - `findSimilarAndContents(url, { text: true })` → `findSimilar(url, { contents: { text: true } })`
    * - `findSimilarAndContents(url, { summary: true })` → `findSimilar(url, { contents: { summary: true } })`
    *
-   * Finds similar links to the provided URL and returns the contents of the documents.
+   * Compatibility wrapper for the legacy top-level contents options shape.
    * @param {string} url - The URL for which to find similar links.
    * @param {FindSimilarOptions & T} [options] - Additional options for finding similar links + contents.
    * @returns {Promise<SearchResponse<T>>} A list of similar search results, including requested contents.

--- a/test/integration/findSimilar.integration.test.ts
+++ b/test/integration/findSimilar.integration.test.ts
@@ -3,10 +3,11 @@ import Exa from "../../src";
 
 const exa = new Exa(process.env.EXA_API_KEY);
 
-describe("FindSimilar Contents Options", () => {
+describe("Deprecated findSimilar contents compatibility", () => {
   const testUrl = "https://en.wikipedia.org/wiki/Ant";
 
-  it("Defaults to providing text contents with 10,000 max characters", async () => {
+  it("preserves deprecated default text contents with 10,000 max characters", async () => {
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, { numResults: 2 });
     expect(response.results).not.toHaveLength(0);
 
@@ -16,7 +17,8 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.text.length).toBeLessThanOrEqual(10_000);
   });
 
-  it("Returns no contents when explicitly set to false", async () => {
+  it("preserves deprecated no-contents option when explicitly set to false", async () => {
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, {
       contents: false,
       numResults: 2,
@@ -28,7 +30,8 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.summary).toBeUndefined();
   });
 
-  it("Returns text contents when explicitly requested", async () => {
+  it("preserves deprecated text contents when explicitly requested", async () => {
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, {
       contents: { text: true },
       numResults: 2,
@@ -40,8 +43,9 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.text.length).toBeGreaterThan(100);
   });
 
-  it("Returns text contents with custom maxCharacters", async () => {
+  it("preserves deprecated text contents with custom maxCharacters", async () => {
     const maxChars = 500;
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, {
       contents: { text: { maxCharacters: maxChars } },
       numResults: 2,
@@ -53,7 +57,8 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.text.length).toBeLessThanOrEqual(maxChars);
   });
 
-  it("Returns summary when requested", async () => {
+  it("preserves deprecated summary contents when requested", async () => {
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, {
       contents: { summary: true },
       numResults: 2,
@@ -66,7 +71,8 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.text).toBeUndefined();
   }, 15000);
 
-  it("Returns both text and summary when both are requested", async () => {
+  it("preserves deprecated text and summary contents when both are requested", async () => {
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, {
       contents: {
         text: { maxCharacters: 1000 },
@@ -84,7 +90,8 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.summary.length).toBeGreaterThan(10);
   }, 20000);
 
-  it("Defaults to text when passing other options without contents", async () => {
+  it("preserves deprecated default text when passing other options without contents", async () => {
+    // DEPRECATED METHOD: compatibility coverage for legacy URL-similarity behavior.
     const response = await exa.findSimilar(testUrl, {
       numResults: 3,
       excludeSourceDomain: true,
@@ -96,4 +103,3 @@ describe("FindSimilar Contents Options", () => {
     expect(sampleResult.text.length).toBeGreaterThan(100);
   });
 });
-

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -66,7 +66,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should perform searchAndContents with text option", async () => {
+  it("should preserve deprecated searchAndContents text option for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -83,6 +83,7 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       text: true,
       numResults: 2,
@@ -98,7 +99,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should properly nest context option under contents", async () => {
+  it("should preserve deprecated searchAndContents context option for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -108,6 +109,7 @@ describe("Search API", () => {
           text: "Sample text content",
         },
       ],
+      // DEPRECATED FIELD: response context remains covered for compatibility.
       context: "This is the context string",
       requestId: "req-123",
     };
@@ -116,8 +118,10 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       text: true,
+      // DEPRECATED FIELD: callers should use contents.text or contents.highlights instead.
       context: true,
       numResults: 2,
     });
@@ -126,6 +130,7 @@ describe("Search API", () => {
       query: "latest AI developments",
       contents: {
         text: true,
+        // DEPRECATED FIELD: compatibility expectation only.
         context: true,
       },
       numResults: 2,
@@ -133,7 +138,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should handle multiple content options correctly", async () => {
+  it("should preserve deprecated searchAndContents context object option for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -151,9 +156,11 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       text: { maxCharacters: 1000 },
       summary: { query: "Summarize this" },
+      // DEPRECATED FIELD: callers should use contents.text or contents.highlights instead.
       context: { maxCharacters: 500 },
       numResults: 3,
     });
@@ -163,6 +170,7 @@ describe("Search API", () => {
       contents: {
         text: { maxCharacters: 1000 },
         summary: { query: "Summarize this" },
+        // DEPRECATED FIELD: compatibility expectation only.
         context: { maxCharacters: 500 },
       },
       numResults: 3,
@@ -170,7 +178,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should handle highlights option with searchAndContents", async () => {
+  it("should preserve deprecated searchAndContents highlights option for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -188,6 +196,7 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       highlights: true,
       numResults: 2,
@@ -203,7 +212,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should handle highlights with detailed options", async () => {
+  it("should preserve deprecated searchAndContents highlights sizing fields for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -221,7 +230,9 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
+      // DEPRECATED FIELDS: callers should use highlights.maxCharacters instead.
       highlights: { numSentences: 2, highlightsPerUrl: 3, query: "key points" },
       numResults: 2,
     });
@@ -230,6 +241,7 @@ describe("Search API", () => {
       query: "latest AI developments",
       contents: {
         highlights: {
+          // DEPRECATED FIELDS: compatibility expectation only.
           numSentences: 2,
           highlightsPerUrl: 3,
           query: "key points",
@@ -240,7 +252,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should handle highlights with maxCharacters option", async () => {
+  it("should preserve deprecated searchAndContents highlights maxCharacters option for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -258,6 +270,7 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       highlights: { maxCharacters: 200, query: "key points" },
       numResults: 2,
@@ -272,7 +285,7 @@ describe("Search API", () => {
     });
     expect(result).toEqual(mockResponse);
   });
-  it("should handle text and highlights together", async () => {
+  it("should preserve deprecated searchAndContents text and highlights options for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -291,6 +304,7 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       text: true,
       highlights: true,
@@ -327,17 +341,17 @@ describe("Search API", () => {
       .mockResolvedValueOnce(mockResponse);
 
     const result = await exa.search("test query", {
-      contents: { highlights: { numSentences: 2 } },
+      contents: { highlights: { maxCharacters: 500 } },
     });
 
     expect(requestSpy).toHaveBeenCalledWith("/search", "POST", {
       query: "test query",
-      contents: { highlights: { numSentences: 2 } },
+      contents: { highlights: { maxCharacters: 500 } },
     });
     expect(result).toEqual(mockResponse);
   });
 
-  it("should default to text with maxCharacters when no content options provided", async () => {
+  it("should preserve deprecated searchAndContents default text behavior for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -354,6 +368,7 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("test query");
 
     expect(requestSpy).toHaveBeenCalledWith("/search", "POST", {
@@ -367,7 +382,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should handle findSimilarAndContents with context", async () => {
+  it("should preserve deprecated findSimilarAndContents context for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -377,6 +392,7 @@ describe("Search API", () => {
           text: "Similar content",
         },
       ],
+      // DEPRECATED FIELD: response context remains covered for compatibility.
       context: "Context for similar results",
       requestId: "req-456",
     };
@@ -385,8 +401,10 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.findSimilarAndContents("https://example.com", {
       text: true,
+      // DEPRECATED FIELD: callers should use contents.text or contents.highlights instead.
       context: true,
       numResults: 5,
     });
@@ -395,6 +413,7 @@ describe("Search API", () => {
       url: "https://example.com",
       contents: {
         text: true,
+        // DEPRECATED FIELD: compatibility expectation only.
         context: true,
       },
       numResults: 5,
@@ -402,7 +421,7 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("should handle livecrawl preferred option in contents", async () => {
+  it("should preserve deprecated searchAndContents livecrawl options for compatibility", async () => {
     const mockResponse = {
       results: [
         {
@@ -419,6 +438,7 @@ describe("Search API", () => {
       .spyOn(exa, "request")
       .mockResolvedValueOnce(mockResponse);
 
+    // DEPRECATED METHOD: compatibility coverage for legacy top-level contents options.
     const result = await exa.searchAndContents("latest AI developments", {
       text: true,
       livecrawl: "preferred",
@@ -582,7 +602,6 @@ describe("Search API", () => {
           text: "Deep search result text",
         },
       ],
-      context: "Deep search context string",
       requestId: "req-deep-123",
     };
 
@@ -608,7 +627,6 @@ describe("Search API", () => {
       },
     });
     expect(result).toEqual(mockResponse);
-    expect(result.context).toBeDefined();
   });
 
   it("should pass outputSchema for deep search", async () => {
@@ -897,7 +915,6 @@ describe("Search API", () => {
           text: "Deep search result text",
         },
       ],
-      context: "Deep search context string",
       requestId: "req-deep-variant-123",
     };
 
@@ -921,7 +938,6 @@ describe("Search API", () => {
       },
     });
     expect(result).toEqual(mockResponse);
-    expect(result.context).toBeDefined();
   });
 
   it("should pass additionalQueries for deep-lite search type", async () => {
@@ -934,7 +950,6 @@ describe("Search API", () => {
           text: "Deep lite search result text",
         },
       ],
-      context: "Deep lite search context string",
       requestId: "req-deep-lite-123",
     };
 
@@ -958,7 +973,6 @@ describe("Search API", () => {
       },
     });
     expect(result).toEqual(mockResponse);
-    expect(result.context).toBeDefined();
   });
 
   it("should pass deep highlights maxCharacters options through contents", async () => {


### PR DESCRIPTION
## Summary

This PR makes deprecated API surface area much harder to miss for TypeScript tooling, generated documentation, and LLM/code readers. It keeps backwards compatibility intact while adding explicit `DEPRECATED:` prose next to the existing `@deprecated` tags and steering examples toward supported replacement patterns.

## Why

Some deprecated fields and methods were only marked in ways that are easy to miss when reading source or generated docs. The goal is to make deprecated usage visually obvious wherever it appears, while preserving legacy behavior for existing callers.

## What Changed

- Marked deprecated fields with both standard `@deprecated` tags and plain `DEPRECATED:` text:
  - `ContentsOptions.context`
  - deep search `context`
  - `HighlightsContentsOptions.numSentences`
  - `HighlightsContentsOptions.highlightsPerUrl`
  - `SearchResponse.context`
  - `ContextOptions`
  - `JSONSchema`
- Marked legacy methods as visibly deprecated:
  - `searchAndContents` -> `search(..., { contents: ... })`
  - `findSimilar`
  - `findSimilarAndContents`
- Updated `findSimilar` and `FindSimilarOptions` docs to point new discovery flows at `search()` and explicitly note that there is no direct replacement for URL-based similarity.
- Updated generated docs config so deprecated fields, options, and methods render with explicit `DEPRECATED:` warnings.
- Updated generated examples for deprecated methods to avoid teaching deprecated calls.
- Kept deprecated usage in tests only as clearly labeled compatibility coverage.
- Removed incidental deprecated `context` assertions from unrelated deep search tests.
- Updated the schema summary example to use `Record<string, unknown>` instead of the deprecated `JSONSchema` alias.

## Compatibility

This is documentation and test-labeling work only. The deprecated fields and methods are still accepted so existing callers should not break.

## Validation

- `npm run test:unit`
- `npm run build-fast`
- `npm run generate-docs` marker checks for `DEPRECATED:` output
- `git diff --check`
