### PR TITLE
[security]: add secret scanning guardrail

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,17 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan working tree
+        run: docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:v8.28.0 detect --source=/repo --no-git --config=/repo/gitleaks.toml --redact --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 .DS_Store
 dist
 *.log
+*.env
 
 tests
 
@@ -9,5 +10,6 @@ tests
 .aider*
 
 .env
-.env.local
+.env.*
+!.env.example
 personal/

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -1,0 +1,15 @@
+title = "exa-js gitleaks config"
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "exa-api-key-assignment"
+description = "Exa API keys must not be committed"
+regex = '''(?i)\b(?:EXA(?:SEARCH)?_API_KEY|api[_-]?key)\s*[:=]\s*["']?[A-Za-z0-9_\-]{20,}["']?'''
+keywords = [
+  "EXA_API_KEY",
+  "EXASEARCH_API_KEY",
+  "api_key",
+  "apikey",
+]


### PR DESCRIPTION
## Summary
- Adds a Secret Scan workflow that runs gitleaks on PRs and pushes to `master`.
- Adds a repo-local gitleaks rule for Exa API key assignments, including `EXA_API_KEY` and `EXASEARCH_API_KEY`.
- Broadens `.gitignore` coverage for env files while keeping `.env.example` allowed.

## Review & Testing Checklist for Human
- [ ] Confirm GitHub Actions runs the new Secret Scan workflow on this PR.
- [ ] Confirm the exposed API key from SEC-36 has been revoked or rotated outside this repo.
- [ ] Decide whether public git history should be rewritten or whether rotation plus CI guardrails is sufficient.

### Notes
- Current `master` does not contain `.env`; the reported key is still present in old public commit history (`fc68f05`).
- Local checks: `docker run --rm -v "$PWD:/repo" zricethezav/gitleaks:v8.28.0 detect --source=/repo --no-git --config=/repo/gitleaks.toml --redact --verbose`, `npm run build`, `npm run typecheck:examples`, `npm run test:unit`.
- `npm run typecheck` currently fails on `examples/zod_summary_example.ts`, and full `npm test` currently fails in the live API `Company Category Search` integration test; both appear unrelated to this PR.

Link to Devin session: https://app.devin.ai/sessions/d2bd2ab8af2f4cababf923951e82fd6c
Requested by: @pschork