### PR TITLE
fix: add education history typing for person entities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -460,6 +460,11 @@ export type EntityPersonPropertiesCompanyRef = {
   name?: string | null;
 };
 
+/** Reference to an institution in education history. */
+export type EntityPersonPropertiesInstitutionRef = {
+  name?: string | null;
+};
+
 /** A single work history entry for a person. */
 export type EntityPersonPropertiesWorkHistoryEntry = {
   title?: string | null;
@@ -468,11 +473,19 @@ export type EntityPersonPropertiesWorkHistoryEntry = {
   company?: EntityPersonPropertiesCompanyRef | null;
 };
 
+/** A single education history entry for a person. */
+export type EntityPersonPropertiesEducationHistoryEntry = {
+  degree?: string | null;
+  dates?: EntityDateRange | null;
+  institution?: EntityPersonPropertiesInstitutionRef | null;
+};
+
 /** Structured properties for a person entity. */
 export type EntityPersonProperties = {
   name?: string | null;
   location?: string | null;
   workHistory?: EntityPersonPropertiesWorkHistoryEntry[];
+  educationHistory?: EntityPersonPropertiesEducationHistoryEntry[];
 };
 
 /** Structured entity data for a company. */

--- a/test/unit/entities.test.ts
+++ b/test/unit/entities.test.ts
@@ -139,6 +139,34 @@ describe("Entity Types", () => {
 
       expect(person.properties.workHistory).toHaveLength(0);
     });
+
+    it("should type education history for person entities", () => {
+      const person: PersonEntity = {
+        id: "https://exa.ai/library/person/brad-vogel",
+        type: "person",
+        version: 1,
+        properties: {
+          name: "Brad Vogel",
+          location: "Washington, DC",
+          educationHistory: [
+            {
+              degree: "BS",
+              dates: {
+                from: "2003-01-01",
+                to: "2007-01-01",
+              },
+              institution: {
+                name: "Virginia Tech",
+              },
+            },
+          ],
+        },
+      };
+
+      expect(person.properties.educationHistory).toHaveLength(1);
+      expect(person.properties.educationHistory?.[0].degree).toBe("BS");
+      expect(person.properties.educationHistory?.[0].institution?.name).toBe("Virginia Tech");
+    });
   });
 
   describe("Entity Union Type", () => {


### PR DESCRIPTION
## Summary
- add typed education-history entries for person entities
- add institution reference typing for education history items
- add a regression test covering person entity education history

## Testing
- npx tsc --noEmit --target es2020 --module esnext --moduleResolution node --strict --esModuleInterop --skipLibCheck --resolveJsonModule --types vitest/globals test/unit/entities.test.ts
- npx vitest run test/unit/entities.test.ts
- npm run test:unit
- npm run build-fast

Fixes #159
