### PR TITLE
fix: support AbortSignal in SDK requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,11 @@ export type ContentsOptions = {
  * @property {string} [userLocation] - The two-letter ISO country code of the user, e.g. US.
  * @property {boolean} [stream] - Whether to stream back OpenAI-style chat completion chunks. Use `streamSearch()` instead of `search({ stream: true })`.
  */
-export type BaseSearchOptions = {
+export type RequestOptions = {
+  signal?: AbortSignal;
+};
+
+export type BaseSearchOptions = RequestOptions & {
   contents?: ContentsOptions;
   numResults?: number;
   includeDomains?: string[];
@@ -580,7 +584,7 @@ export type Status = {
  * @property {string} [systemPrompt] - A system prompt to guide the LLM's behavior when generating the answer.
  * @property {Object} [outputSchema] - A JSON Schema specification for the structure you expect the output to take
  */
-export type AnswerOptions = {
+export type AnswerOptions = RequestOptions & {
   stream?: boolean;
   text?: boolean;
   model?: "exa";
@@ -837,7 +841,8 @@ export class Exa {
     method: string,
     body?: any,
     params?: Record<string, any>,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<T> {
     // Build URL with query parameters if provided
     let url = this.baseURL + endpoint;
@@ -869,10 +874,22 @@ export class Exa {
       combinedHeaders = { ...combinedHeaders, ...headers };
     }
 
+    let requestBody = body;
+    let requestSignal = signal;
+
+    if (body && typeof body === "object" && !Array.isArray(body) && "signal" in body) {
+      const { signal: embeddedSignal, ...restBody } = body as {
+        signal?: AbortSignal;
+      } & Record<string, unknown>;
+      requestBody = restBody;
+      requestSignal ??= embeddedSignal;
+    }
+
     const response = await fetchImpl(url, {
       method,
       headers: combinedHeaders,
-      body: body ? JSON.stringify(body) : undefined,
+      body: requestBody ? JSON.stringify(requestBody) : undefined,
+      signal: requestSignal,
     });
 
     if (!response.ok) {
@@ -918,7 +935,8 @@ export class Exa {
       string,
       string | number | boolean | string[] | undefined
     >,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Response> {
     let url = this.baseURL + endpoint;
 
@@ -950,10 +968,22 @@ export class Exa {
       combinedHeaders = { ...combinedHeaders, ...headers };
     }
 
+    let requestBody = body;
+    let requestSignal = signal;
+
+    if (body && typeof body === "object" && !Array.isArray(body) && "signal" in body) {
+      const { signal: embeddedSignal, ...restBody } = body as {
+        signal?: AbortSignal;
+      } & Record<string, unknown>;
+      requestBody = restBody;
+      requestSignal ??= embeddedSignal;
+    }
+
     const response = await fetchImpl(url, {
       method,
       headers: combinedHeaders,
-      body: body ? JSON.stringify(body) : undefined,
+      body: requestBody ? JSON.stringify(requestBody) : undefined,
+      signal: requestSignal,
     });
 
     return response;
@@ -1210,7 +1240,7 @@ export class Exa {
    */
   async getContents<T extends ContentsOptions>(
     urls: string | string[] | SearchResult<T>[],
-    options?: T
+    options?: T & RequestOptions
   ): Promise<SearchResponse<T>> {
     if (!urls || (Array.isArray(urls) && urls.length === 0)) {
       throw new ExaError(
@@ -1299,6 +1329,7 @@ export class Exa {
       systemPrompt: options?.systemPrompt,
       outputSchema,
       userLocation: options?.userLocation,
+      signal: options?.signal,
     };
 
     return await this.request("/answer", "POST", requestBody);
@@ -1316,6 +1347,7 @@ export class Exa {
       systemPrompt?: string;
       outputSchema: ZodSchema<T>;
       userLocation?: string;
+      signal?: AbortSignal;
     }
   ): AsyncGenerator<AnswerStreamChunk>;
 
@@ -1346,6 +1378,7 @@ export class Exa {
       systemPrompt?: string;
       outputSchema?: Record<string, unknown>;
       userLocation?: string;
+      signal?: AbortSignal;
     }
   ): AsyncGenerator<AnswerStreamChunk>;
 
@@ -1357,6 +1390,7 @@ export class Exa {
       systemPrompt?: string;
       outputSchema?: Record<string, unknown> | ZodSchema<T>;
       userLocation?: string;
+      signal?: AbortSignal;
     }
   ): AsyncGenerator<AnswerStreamChunk> {
     // Convert Zod schema to JSON schema if needed
@@ -1374,6 +1408,7 @@ export class Exa {
       systemPrompt: options?.systemPrompt,
       outputSchema,
       userLocation: options?.userLocation,
+      signal: options?.signal,
     };
 
     yield* this.streamChatCompletions("/answer", body);

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -66,6 +66,66 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("forwards AbortSignal on search without serializing it into the request body", async () => {
+    vi.resetModules();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [], requestId: "req-123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: FreshExa } = await import("../../src");
+    const freshExa = new FreshExa("test-api-key", "https://api.exa.ai");
+    const controller = new AbortController();
+
+    await freshExa.search("latest AI developments", {
+      numResults: 2,
+      signal: controller.signal,
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+    expect(JSON.parse(String(init.body))).toEqual({
+      query: "latest AI developments",
+      numResults: 2,
+      contents: {
+        text: {
+          maxCharacters: 10000,
+        },
+      },
+    });
+  });
+
+  it("forwards AbortSignal on streamSearch", async () => {
+    vi.resetModules();
+    const fetchMock = vi.fn().mockResolvedValue(
+      createSseResponse([
+        'data: {"choices":[{"delta":{"content":"hello"}}]}',
+        "data: [DONE]",
+      ])
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: FreshExa } = await import("../../src");
+    const freshExa = new FreshExa("test-api-key", "https://api.exa.ai");
+    const controller = new AbortController();
+
+    const chunks: SearchStreamChunk[] = [];
+    for await (const chunk of freshExa.streamSearch("latest AI developments", {
+      signal: controller.signal,
+    })) {
+      chunks.push(chunk);
+    }
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      query: "latest AI developments",
+      stream: true,
+    });
+    expect(chunks[0]?.content).toBe("hello");
+  });
+
   it("should preserve deprecated searchAndContents text option for compatibility", async () => {
     const mockResponse = {
       results: [


### PR DESCRIPTION
## Summary
- add a top-level `signal` option for SDK request methods
- thread `AbortSignal` through the shared request helpers so it reaches `fetch`
- strip `signal` from JSON payloads before serializing requests
- add regression tests for both regular search and streaming search paths

## Testing
- copied the new search AbortSignal tests onto upstream `master` in a temporary worktree and verified they failed there
- npx tsc --noEmit --target es2020 --module esnext --moduleResolution node --strict --esModuleInterop --skipLibCheck --resolveJsonModule --types vitest/globals test/unit/search.test.ts
- npx vitest run test/unit/search.test.ts -t 'forwards AbortSignal'
- npm run test:unit
- npm run build-fast

Fixes #158
