### PR TITLE
fix: wrap non-json api responses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -823,6 +823,31 @@ export class Exa {
     this.beta = new BetaClient(this);
   }
 
+  private async parseJsonResponse<T>(
+    response: Response,
+    endpoint: string
+  ): Promise<T> {
+    const responseText = await response.text();
+
+    try {
+      return JSON.parse(responseText) as T;
+    } catch (error) {
+      const preview = responseText
+        ? responseText.slice(0, 300).replace(/\s+/g, " ").trim()
+        : "<empty response body>";
+      const message = response.ok
+        ? `Invalid JSON response from Exa API at ${endpoint}: ${preview}`
+        : `Exa API request failed with non-JSON response at ${endpoint}: ${preview}`;
+
+      throw new ExaError(
+        message,
+        response.status,
+        new Date().toISOString(),
+        endpoint
+      );
+    }
+  }
+
   /**
    * Makes a request to the Exa API.
    * @param {string} endpoint - The API endpoint to call.
@@ -876,7 +901,10 @@ export class Exa {
     });
 
     if (!response.ok) {
-      const errorData = await response.json();
+      const errorData = await this.parseJsonResponse<Record<string, any>>(
+        response,
+        endpoint
+      );
 
       if (!errorData.statusCode) {
         errorData.statusCode = response.status;
@@ -907,7 +935,7 @@ export class Exa {
       return (await this.parseSSEStream<T>(response)) as T;
     }
 
-    return (await response.json()) as T;
+    return await this.parseJsonResponse<T>(response, endpoint);
   }
 
   async rawRequest(

--- a/test/unit/request-error.test.ts
+++ b/test/unit/request-error.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+async function createClientWithFetch(fetchMock: ReturnType<typeof vi.fn>) {
+  vi.resetModules();
+  vi.stubGlobal("fetch", fetchMock);
+  const { default: Exa } = await import("../../src");
+  return new Exa("test-api-key", "https://api.exa.ai");
+}
+
+describe("Request error handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("wraps non-JSON error responses in ExaError", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("<!DOCTYPE html><html>cloudflare 502</html>", {
+        status: 502,
+        headers: { "content-type": "text/html" },
+      })
+    );
+    const exa = await createClientWithFetch(fetchMock);
+
+    await expect(exa.search("agent observability")).rejects.toMatchObject({
+      name: "ExaError",
+      statusCode: 502,
+      path: "/search",
+      message: expect.stringContaining(
+        "Exa API request failed with non-JSON response"
+      ),
+    });
+  });
+
+  it("wraps invalid successful JSON responses in ExaError", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    const exa = await createClientWithFetch(fetchMock);
+
+    await expect(exa.search("agent observability")).rejects.toMatchObject({
+      name: "ExaError",
+      statusCode: 200,
+      path: "/search",
+      message: expect.stringContaining("Invalid JSON response from Exa API"),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- parse regular JSON responses via a shared text-first helper
- convert non-JSON error responses, e.g. Cloudflare HTML/empty bodies, into `ExaError` instead of leaking `SyntaxError`
- include endpoint path, HTTP status, timestamp, and a short sanitized response preview for debugging

Fixes #139
Refs #92

## Testing
- `node node_modules/typescript/bin/tsc --noEmit --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --resolveJsonModule --skipLibCheck src/index.ts test/unit/request-error.test.ts`
- `ROLLUP_SKIP_NODEJS_NATIVE=1 node node_modules/vitest/vitest.mjs run --config vitest.unit.config.ts test/unit/request-error.test.ts`
- `ROLLUP_SKIP_NODEJS_NATIVE=1 node node_modules/vitest/vitest.mjs run --config vitest.unit.config.ts test/unit/request-error.test.ts test/unit/search.test.ts`
- `node node_modules/prettier/bin/prettier.cjs --check src/index.ts test/unit/request-error.test.ts`

## Notes
- I checked for contribution/CLA docs in the repo and did not find a CLA or PR template.
- `npm run typecheck` currently fails on unrelated existing example/test type errors in `examples/zod_summary_example.ts`, `test/unit/websets.test.ts`, etc.
- `npm run build-fast` is blocked in my local macOS Codex runtime by Rollup's optional native package loading issue (`@rollup/rollup-darwin-arm64`), so I verified this patch with the targeted TypeScript and Vitest commands above.
- AI assistance was used to draft/review the patch; I ran the listed local checks myself.
