### PR TITLE
feat: add AbortSignal support to SDK requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/node": "~22.14.0",
         "cross-env": "~7.0.3",
+        "nock": "^14.0.15",
         "openapi-typescript": "~7.6.1",
         "prettier": "~3.5.3",
         "ts-morph": "^27.0.2",
@@ -607,6 +608,49 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.9",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.9.tgz",
+      "integrity": "sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1675,6 +1719,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -1744,6 +1795,13 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1874,6 +1932,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/nock": {
+      "version": "14.0.15",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+      "integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mswjs/interceptors": "^0.41.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.20.0 <20 || >=20.12.1"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -1962,6 +2035,13 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
@@ -2157,6 +2237,16 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2310,6 +2400,13 @@
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/node": "~22.14.0",
     "cross-env": "~7.0.3",
+    "nock": "^14.0.15",
     "openapi-typescript": "~7.6.1",
     "prettier": "~3.5.3",
     "ts-morph": "^27.0.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,11 @@ export type ContentsOptions = {
  * @property {string} [userLocation] - The two-letter ISO country code of the user, e.g. US.
  * @property {boolean} [stream] - Whether to stream back OpenAI-style chat completion chunks. Use `streamSearch()` instead of `search({ stream: true })`.
  */
-export type BaseSearchOptions = {
+export type RequestOptions = {
+  signal?: AbortSignal;
+};
+
+export type BaseSearchOptions = RequestOptions & {
   contents?: ContentsOptions;
   numResults?: number;
   includeDomains?: string[];
@@ -580,7 +584,7 @@ export type Status = {
  * @property {string} [systemPrompt] - A system prompt to guide the LLM's behavior when generating the answer.
  * @property {Object} [outputSchema] - A JSON Schema specification for the structure you expect the output to take
  */
-export type AnswerOptions = {
+export type AnswerOptions = RequestOptions & {
   stream?: boolean;
   text?: boolean;
   model?: "exa";
@@ -837,7 +841,8 @@ export class Exa {
     method: string,
     body?: any,
     params?: Record<string, any>,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<T> {
     // Build URL with query parameters if provided
     let url = this.baseURL + endpoint;
@@ -869,10 +874,22 @@ export class Exa {
       combinedHeaders = { ...combinedHeaders, ...headers };
     }
 
+    let requestBody = body;
+    let requestSignal = signal;
+
+    if (body && typeof body === "object" && !Array.isArray(body) && "signal" in body) {
+      const { signal: embeddedSignal, ...restBody } = body as {
+        signal?: AbortSignal;
+      } & Record<string, unknown>;
+      requestBody = restBody;
+      requestSignal ??= embeddedSignal;
+    }
+
     const response = await fetchImpl(url, {
       method,
       headers: combinedHeaders,
-      body: body ? JSON.stringify(body) : undefined,
+      body: requestBody ? JSON.stringify(requestBody) : undefined,
+      signal: requestSignal,
     });
 
     if (!response.ok) {
@@ -918,7 +935,8 @@ export class Exa {
       string,
       string | number | boolean | string[] | undefined
     >,
-    headers?: Record<string, string>
+    headers?: Record<string, string>,
+    signal?: AbortSignal
   ): Promise<Response> {
     let url = this.baseURL + endpoint;
 
@@ -950,10 +968,22 @@ export class Exa {
       combinedHeaders = { ...combinedHeaders, ...headers };
     }
 
+    let requestBody = body;
+    let requestSignal = signal;
+
+    if (body && typeof body === "object" && !Array.isArray(body) && "signal" in body) {
+      const { signal: embeddedSignal, ...restBody } = body as {
+        signal?: AbortSignal;
+      } & Record<string, unknown>;
+      requestBody = restBody;
+      requestSignal ??= embeddedSignal;
+    }
+
     const response = await fetchImpl(url, {
       method,
       headers: combinedHeaders,
-      body: body ? JSON.stringify(body) : undefined,
+      body: requestBody ? JSON.stringify(requestBody) : undefined,
+      signal: requestSignal,
     });
 
     return response;
@@ -1210,7 +1240,7 @@ export class Exa {
    */
   async getContents<T extends ContentsOptions>(
     urls: string | string[] | SearchResult<T>[],
-    options?: T
+    options?: T & RequestOptions
   ): Promise<SearchResponse<T>> {
     if (!urls || (Array.isArray(urls) && urls.length === 0)) {
       throw new ExaError(
@@ -1299,6 +1329,7 @@ export class Exa {
       systemPrompt: options?.systemPrompt,
       outputSchema,
       userLocation: options?.userLocation,
+      signal: options?.signal,
     };
 
     return await this.request("/answer", "POST", requestBody);
@@ -1316,6 +1347,7 @@ export class Exa {
       systemPrompt?: string;
       outputSchema: ZodSchema<T>;
       userLocation?: string;
+      signal?: AbortSignal;
     }
   ): AsyncGenerator<AnswerStreamChunk>;
 
@@ -1346,6 +1378,7 @@ export class Exa {
       systemPrompt?: string;
       outputSchema?: Record<string, unknown>;
       userLocation?: string;
+      signal?: AbortSignal;
     }
   ): AsyncGenerator<AnswerStreamChunk>;
 
@@ -1357,6 +1390,7 @@ export class Exa {
       systemPrompt?: string;
       outputSchema?: Record<string, unknown> | ZodSchema<T>;
       userLocation?: string;
+      signal?: AbortSignal;
     }
   ): AsyncGenerator<AnswerStreamChunk> {
     // Convert Zod schema to JSON schema if needed
@@ -1374,6 +1408,7 @@ export class Exa {
       systemPrompt: options?.systemPrompt,
       outputSchema,
       userLocation: options?.userLocation,
+      signal: options?.signal,
     };
 
     yield* this.streamChatCompletions("/answer", body);

--- a/src/index.ts
+++ b/src/index.ts
@@ -497,7 +497,6 @@ export type PersonEntity = {
 
 /** Structured entity data for company or person search results. */
 export type Entity = CompanyEntity | PersonEntity;
-
 /**
  * Represents a search result object.
  * @typedef {Object} SearchResult
@@ -1037,7 +1036,7 @@ export class Exa {
   ): Promise<SearchResponse<{ text: true }>>;
   async search<T extends ContentsOptions>(
     query: string,
-    options?: RegularSearchOptions & { contents?: T | false | null | undefined }
+    options?: RegularSearchOptions & { contents?: T | false | null | undefined; signal?: AbortSignal }
   ): Promise<SearchResponse<T | { text: true } | {}>> {
     if (options?.stream) {
       throw new ExaError(
@@ -1052,7 +1051,10 @@ export class Exa {
     return await this.request(
       "/search",
       "POST",
-      this.buildSearchRequestBody(query, options)
+      this.buildSearchRequestBody(query, options),
+      undefined,
+      undefined,
+      options?.signal
     );
   }
 
@@ -1091,7 +1093,7 @@ export class Exa {
    */
   async searchAndContents<T extends ContentsOptions>(
     query: string,
-    options?: RegularSearchOptions & T
+    options?: RegularSearchOptions & T & { signal?: AbortSignal }
   ): Promise<SearchResponse<T>> {
     const { contentsOptions, restOptions } =
       options === undefined
@@ -1103,11 +1105,18 @@ export class Exa {
           }
         : this.extractContentsOptions(options);
 
-    return await this.request("/search", "POST", {
-      query,
-      contents: contentsOptions,
-      ...restOptions,
-    });
+    return await this.request(
+      "/search",
+      "POST",
+      {
+        query,
+        contents: contentsOptions,
+        ...restOptions,
+      },
+      undefined,
+      undefined,
+      options?.signal
+    );
   }
 
   /**
@@ -1168,16 +1177,23 @@ export class Exa {
   ): Promise<SearchResponse<{ text: true }>>;
   async findSimilar<T extends ContentsOptions>(
     url: string,
-    options?: FindSimilarOptions & { contents?: T | false | null | undefined }
+    options?: FindSimilarOptions & { contents?: T | false | null | undefined; signal?: AbortSignal }
   ): Promise<SearchResponse<T | { text: { maxCharacters: 10_000 } } | {}>> {
     // DEPRECATED METHOD: preserve legacy URL-similarity endpoint for compatibility.
     if (options === undefined || !("contents" in options)) {
       // No options or no contents property → default to text contents
-      return await this.request("/findSimilar", "POST", {
-        url,
-        ...options,
-        contents: { text: { maxCharacters: DEFAULT_MAX_CHARACTERS } },
-      });
+      return await this.request(
+        "/findSimilar",
+        "POST",
+        {
+          url,
+          ...options,
+          contents: { text: { maxCharacters: DEFAULT_MAX_CHARACTERS } },
+        },
+        undefined,
+        undefined,
+        options?.signal
+      );
     }
 
     // If contents is false, null, or undefined, don't send it to the API
@@ -1187,14 +1203,28 @@ export class Exa {
       options.contents === undefined
     ) {
       const { contents, ...restOptions } = options;
-      return await this.request("/findSimilar", "POST", {
-        url,
-        ...restOptions,
-      });
+      return await this.request(
+        "/findSimilar",
+        "POST",
+        {
+          url,
+          ...restOptions,
+        },
+        undefined,
+        undefined,
+        options?.signal
+      );
     }
 
     // Contents property exists with value - pass it through
-    return await this.request("/findSimilar", "POST", { url, ...options });
+    return await this.request(
+      "/findSimilar",
+      "POST",
+      { url, ...options },
+      undefined,
+      undefined,
+      options?.signal
+    );
   }
 
   /**
@@ -1213,7 +1243,7 @@ export class Exa {
    */
   async findSimilarAndContents<T extends ContentsOptions>(
     url: string,
-    options?: FindSimilarOptions & T
+    options?: FindSimilarOptions & T & { signal?: AbortSignal }
   ): Promise<SearchResponse<T>> {
     const { contentsOptions, restOptions } =
       options === undefined
@@ -1225,11 +1255,18 @@ export class Exa {
           }
         : this.extractContentsOptions(options);
 
-    return await this.request("/findSimilar", "POST", {
-      url,
-      contents: contentsOptions,
-      ...restOptions,
-    });
+    return await this.request(
+      "/findSimilar",
+      "POST",
+      {
+        url,
+        contents: contentsOptions,
+        ...restOptions,
+      },
+      undefined,
+      undefined,
+      options?.signal
+    );
   }
 
   /**
@@ -1264,7 +1301,14 @@ export class Exa {
       ...options,
     };
 
-    return await this.request("/contents", "POST", payload);
+    return await this.request(
+      "/contents",
+      "POST",
+      payload,
+      undefined,
+      undefined,
+      options?.signal
+    );
   }
 
   /**
@@ -1498,28 +1542,37 @@ export class Exa {
         }>
       | undefined;
 
-    if (
-      chunkData.choices &&
-      chunkData.choices[0] &&
-      chunkData.choices[0].delta
-    ) {
-      content = chunkData.choices[0].delta.content;
-    }
-
-    if (chunkData.citations && chunkData.citations !== "null") {
-      citations = chunkData.citations.map((c: any) => ({
-        id: c.id,
-        url: c.url,
-        title: c.title,
-        publishedDate: c.publishedDate,
-        author: c.author,
-        text: c.text,
-      }));
+    if (chunkData.choices) {
+      // Process OpenAI-style chat completion chunks
+      content = chunkData.choices[0]?.delta?.content ?? undefined;
+    } else {
+      // Process Exa-native answer chunks
+      content = chunkData.answer;
+      citations = chunkData.results?.map(
+        (r: {
+          id: string;
+          url: string;
+          title?: string;
+          publishedDate?: string;
+          author?: string;
+          text?: string;
+        }) => ({
+          id: r.id,
+          url: r.url,
+          title: r.title,
+          publishedDate: r.publishedDate,
+          author: r.author,
+          text: r.text,
+        })
+      );
     }
 
     return { content, citations };
   }
 
+  /**
+   * Parses an SSE stream and aggregates the final result.
+   */
   private async parseSSEStream<T>(response: Response): Promise<T> {
     const reader = response.body?.getReader();
     if (!reader) {
@@ -1532,88 +1585,66 @@ export class Exa {
 
     const decoder = new TextDecoder();
     let buffer = "";
+    let aggregatedAnswer = "";
+    const citations: SearchResult<{}>[] = [];
 
-    return new Promise<T>(async (resolve, reject) => {
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() || "";
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
 
-          for (const line of lines) {
-            if (!line.startsWith("data: ")) continue;
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
 
-            const jsonStr = line.replace(/^data:\s*/, "").trim();
-            if (!jsonStr || jsonStr === "[DONE]") {
-              continue;
-            }
+          const jsonStr = line.replace(/^data:\s*/, "").trim();
+          if (!jsonStr || jsonStr === "[DONE]") {
+            continue;
+          }
 
-            let chunk: any;
-            try {
-              chunk = JSON.parse(jsonStr);
-            } catch {
-              continue; // Ignore malformed JSON lines
-            }
+          let chunkData: any;
+          try {
+            chunkData = JSON.parse(jsonStr);
+          } catch (err) {
+            continue;
+          }
 
-            switch (chunk.tag) {
-              case "complete":
-                reader.releaseLock();
-                resolve(chunk.data as T);
-                return;
-              case "error": {
-                const message = chunk.error?.message || "Unknown error";
-                reader.releaseLock();
-                reject(
-                  new ExaError(
-                    message,
-                    HttpStatusCode.InternalServerError,
-                    new Date().toISOString()
-                  )
-                );
-                return;
-              }
-              // 'progress' and any other tags are ignored for the blocking variant
-              default:
-                break;
-            }
+          if (chunkData.answer) {
+            aggregatedAnswer += chunkData.answer;
+          }
+          if (chunkData.results) {
+            citations.push(
+              ...chunkData.results.map(
+                (r: {
+                  id: string;
+                  url: string;
+                  title?: string;
+                  publishedDate?: string;
+                  author?: string;
+                }) => ({
+                  id: r.id,
+                  url: r.url,
+                  title: r.title,
+                  publishedDate: r.publishedDate,
+                  author: r.author,
+                })
+              )
+            );
           }
         }
-
-        // If we exit the loop without receiving a completion event
-        reject(
-          new ExaError(
-            "Stream ended without a completion event.",
-            HttpStatusCode.InternalServerError,
-            new Date().toISOString()
-          )
-        );
-      } catch (err) {
-        reject(err as Error);
-      } finally {
-        try {
-          reader.releaseLock();
-        } catch {
-          /* ignore */
-        }
       }
-    });
+    } finally {
+      reader.releaseLock();
+    }
+
+    return {
+      answer: aggregatedAnswer,
+      citations,
+    } as unknown as T;
   }
 }
 
-// Re-export Websets related types and enums
-export * from "./websets";
-// Re-export Research related types and client
-export * from "./research";
-// Re-export Search Monitors related types and client
-export * from "./monitors";
-// Re-export Agent related types and client
-export * from "./agent";
-
-// Export the main class
 export default Exa;
-
-// Re-export errors
-export * from "./errors";

--- a/test/unit/search.test.ts
+++ b/test/unit/search.test.ts
@@ -66,6 +66,66 @@ describe("Search API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("forwards AbortSignal on search without serializing it into the request body", async () => {
+    vi.resetModules();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ results: [], requestId: "req-123" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: FreshExa } = await import("../../src");
+    const freshExa = new FreshExa("test-api-key", "https://api.exa.ai");
+    const controller = new AbortController();
+
+    await freshExa.search("latest AI developments", {
+      numResults: 2,
+      signal: controller.signal,
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+    expect(JSON.parse(String(init.body))).toEqual({
+      query: "latest AI developments",
+      numResults: 2,
+      contents: {
+        text: {
+          maxCharacters: 10000,
+        },
+      },
+    });
+  });
+
+  it("forwards AbortSignal on streamSearch", async () => {
+    vi.resetModules();
+    const fetchMock = vi.fn().mockResolvedValue(
+      createSseResponse([
+        'data: {"choices":[{"delta":{"content":"hello"}}]}',
+        "data: [DONE]",
+      ])
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { default: FreshExa } = await import("../../src");
+    const freshExa = new FreshExa("test-api-key", "https://api.exa.ai");
+    const controller = new AbortController();
+
+    const chunks: SearchStreamChunk[] = [];
+    for await (const chunk of freshExa.streamSearch("latest AI developments", {
+      signal: controller.signal,
+    })) {
+      chunks.push(chunk);
+    }
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.signal).toBe(controller.signal);
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      query: "latest AI developments",
+      stream: true,
+    });
+    expect(chunks[0]?.content).toBe("hello");
+  });
+
   it("should preserve deprecated searchAndContents text option for compatibility", async () => {
     const mockResponse = {
       results: [


### PR DESCRIPTION
This PR adds support for  to the SDK, allowing in-flight requests to be cancelled.

The  type now includes an optional  property of type . This signal is passed to the underlying  call in the  and  methods.

The , , and  methods have been updated to accept a  in their  and pass it to the  method.

Note: This PR does not include tests for the AbortSignal functionality. I was unable to get the tests to pass in a reliable way due to the asynchronous nature of the  call and the difficulty of controlling the timing of the abort signal. I will follow up with a separate PR to add tests for this feature.