### PR TITLE
fix(monitors): type SearchMonitorRunOutput.content as string | object

### DIFF
--- a/src/monitors/types.ts
+++ b/src/monitors/types.ts
@@ -64,7 +64,11 @@ export interface GroundingEntry {
 
 export interface SearchMonitorRunOutput {
   results?: Record<string, unknown>[] | null;
-  content?: string | null;
+  /**
+   * Synthesized output. When the monitor is configured with an `outputSchema`,
+   * the API returns this as a structured object; otherwise it is a string.
+   */
+  content?: string | Record<string, unknown> | null;
   grounding?: GroundingEntry[] | null;
 }
 

--- a/test/unit/monitors.test.ts
+++ b/test/unit/monitors.test.ts
@@ -283,6 +283,25 @@ describe("Search Monitors API", () => {
       expect(result).toEqual(mockResponse);
     });
 
+    it("should accept structured object content for outputSchema runs", async () => {
+      const structuredContent = { summary: "AI breakthroughs", count: 3 };
+      const mockResponse: SearchMonitorRun = {
+        ...createMockMonitorRun(),
+        output: {
+          results: null,
+          content: structuredContent,
+          grounding: null,
+        },
+      };
+
+      const runsClient = getProtectedClient(exa.monitors.runs);
+      vi.spyOn(runsClient, "request").mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.monitors.runs.get("sm_123456", "run_123456");
+
+      expect(result.output?.content).toEqual(structuredContent);
+    });
+
     it("should paginate through all runs with listAll", async () => {
       const run1 = { ...createMockMonitorRun(), id: "run_1" };
       const run2 = { ...createMockMonitorRun(), id: "run_2" };


### PR DESCRIPTION
## Summary
Companion to the exa-py fix ([exa-py#211](https://github.com/exa-labs/exa-py/pull/211)). A search monitor configured with an `outputSchema` returns `output.content` as a structured JSON **object**, but the TS type only allowed `string | null`. Widen it to match the established `DeepSearchOutput.content` convention:

```diff
 export interface SearchMonitorRunOutput {
   results?: Record<string, unknown>[] | null;
-  content?: string | null;
+  content?: string | Record<string, unknown> | null;
   grounding?: GroundingEntry[] | null;
 }
```

Unlike the Python SDK, exa-js does no runtime validation (`request<SearchMonitorRun>` just casts the JSON), so this never threw — but consumers reading `run.output.content` for an `outputSchema` monitor got the wrong static type (`string` instead of the object the API actually returns). The API behavior was confirmed live in the exa-py session: monitor runs return `content` as a dict when an `outputSchema` is set.

## Changes
- `src/monitors/types.ts`: widen `SearchMonitorRunOutput.content` to `string | Record<string, unknown> | null` (with a JSDoc note).
- `test/unit/monitors.test.ts`: add a test asserting `runs.get` returns object `content` for `outputSchema` runs.

No version bump (this repo bumps versions in dedicated PRs). All 120 unit tests pass; this change adds zero new `tsc` errors (the 48 pre-existing typecheck errors live in unrelated websets tests and are not run in CI).

Link to Devin session: https://app.devin.ai/sessions/766bce30752c42d3a86863884adc7631
Requested by: @maxwbuckley
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->