### PR TITLE
Bump exa-js version to 2.13.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "2.13.0",
+      "version": "2.13.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
Release bump `2.13.0` → `2.13.1` so the fixes already merged on `master` get published to npm. npm `latest` is currently `2.13.0` (the agent-api SDK release), but two fixes have landed since with no version bump:

- #174 — `fix(monitors): type SearchMonitorRunOutput.content as string | object`
- #172 — `fix(client): surface real HTTP error when response body is not JSON`

Only the version is bumped here (`package.json` + `package-lock.json`); no source changes. After merge, the npm publish is done by dispatching the `Publish to npm` workflow against `master`.

Link to Devin session: https://app.devin.ai/sessions/d863924da77142a18f0c4bab5f712d12
Requested by: @maxwbuckley
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->