### PR TITLE
Reflect decimal Agent ACUs in tests

### DIFF
--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -47,7 +47,7 @@ describe("Agent API", () => {
         },
       ],
     },
-    usage: { agentComputeUnits: 100, searches: 2 },
+    usage: { agentComputeUnits: 0.1, searches: 2 },
     costDollars: { total: 0.02, agentCompute: 0.01, search: 0.01 },
   });
 
@@ -79,8 +79,8 @@ describe("Agent API", () => {
       query: "Find recent funding rounds.",
       systemPrompt: "Prefer primary sources.",
       input: { data: [{ company: "Example AI" }] },
-      outputSchema: { type: "object" },
-      effort: "high",
+      outputSchema: { type: "object" as const },
+      effort: "high" as const,
       metadata: { workflow: "funding-watch" },
     };
     const result = await exa.beta.agent.runs.create(params);


### PR DESCRIPTION
## Summary

Update the Agent unit-test fixture to reflect decimal ACU values from the Agent API.

## Details

The TypeScript SDK already types `AgentUsage.agentComputeUnits` as `number`, which supports both integers and decimals. No public type change is needed. This PR updates the Agent test fixture from `100` ACUs to `0.1` ACUs so the SDK test surface reflects the new API response shape, and keeps the fixture literals narrow enough for TypeScript overload resolution.

## OpenAPI

No change is needed in the separate `openapi-spec` repo: `origin/master` there does not include the Agent API or `agentComputeUnits`. The public Agent OpenAPI schema is owned by Nova in the monorepo and has already been updated to `type: number`.

## Validation

- `npx vitest run --config vitest.unit.config.ts test/unit/agent.test.ts`
- `npm run build`
- `git diff --check`

`npm run typecheck` still reports unrelated existing errors on current master in examples, websets tests, request-error handling tests, and integration test typings. The Agent unit test no longer appears in that typecheck output.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/exa-labs/exa-js/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->