### PR TITLE
[codex] add responses client

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { BetaClient } from "./agent/client";
 import { ExaError, HttpStatusCode } from "./errors";
 import { SearchMonitorsClient } from "./monitors/client";
 import { ResearchClient } from "./research/client";
+import { ResponsesClient } from "./responses/client";
 import { WebsetsClient } from "./websets/client";
 import { isZodSchema, zodToJsonSchema } from "./zod-utils";
 
@@ -727,6 +728,11 @@ export class Exa {
   monitors: SearchMonitorsClient;
 
   /**
+   * OpenAI-compatible Responses API client
+   */
+  responses: ResponsesClient;
+
+  /**
    * Beta API clients
    */
   beta: BetaClient;
@@ -860,6 +866,8 @@ export class Exa {
     this.research = new ResearchClient(this);
     // Initialize the Search Monitors client
     this.monitors = new SearchMonitorsClient(this);
+    // Initialize the OpenAI-compatible Responses client
+    this.responses = new ResponsesClient(this);
     // Initialize beta clients
     this.beta = new BetaClient(this);
   }
@@ -1645,6 +1653,8 @@ export * from "./websets";
 export * from "./research";
 // Re-export Search Monitors related types and client
 export * from "./monitors";
+// Re-export Responses related types and client
+export * from "./responses";
 // Re-export Agent related types and client
 export * from "./agent";
 

--- a/src/responses/client.ts
+++ b/src/responses/client.ts
@@ -1,0 +1,26 @@
+/**
+ * Client for Exa's OpenAI-compatible Responses API.
+ */
+
+import { Exa } from "../index";
+import { Response, ResponseCreateParams } from "./types";
+
+export class ResponsesClient {
+  constructor(private readonly client: Exa) {}
+
+  /**
+   * Create a non-streaming Agent response.
+   */
+  async create(params: ResponseCreateParams): Promise<Response> {
+    if (params.stream) {
+      throw new Error("Streaming Responses are not supported yet.");
+    }
+
+    const payload: ResponseCreateParams = {
+      model: "agent",
+      ...params,
+    };
+
+    return this.client.request<Response>("/v1/responses", "POST", payload);
+  }
+}

--- a/src/responses/client.ts
+++ b/src/responses/client.ts
@@ -21,6 +21,6 @@ export class ResponsesClient {
       ...params,
     };
 
-    return this.client.request<Response>("/v1/responses", "POST", payload);
+    return this.client.request<Response>("/responses", "POST", payload);
   }
 }

--- a/src/responses/index.ts
+++ b/src/responses/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Exa OpenAI-compatible Responses API client.
+ */
+
+export { ResponsesClient } from "./client";
+export type {
+  AgentResponseEffort,
+  AgentResponseModel,
+  Response,
+  ResponseCreateParams,
+  ResponseError,
+  ResponseIncompleteDetails,
+  ResponseInput,
+  ResponseInputMessage,
+  ResponseOutputMessage,
+  ResponseOutputText,
+  ResponseReasoningParam,
+  ResponseStatus,
+  ResponseTextConfigParam,
+  ResponseTextFormatParam,
+} from "./types";

--- a/src/responses/types.ts
+++ b/src/responses/types.ts
@@ -1,0 +1,123 @@
+/**
+ * Types for Exa's OpenAI-compatible Responses API.
+ */
+
+export type AgentResponseModel = "agent" | "exa-agent";
+
+export type AgentResponseEffort = "low" | "medium" | "high" | "xhigh" | "auto";
+
+export type ResponseStatus =
+  | "completed"
+  | "failed"
+  | "incomplete"
+  | "queued"
+  | "running";
+
+export interface ResponseReasoningParam {
+  /**
+   * Agent effort mode.
+   */
+  effort?: AgentResponseEffort | null;
+  [key: string]: unknown;
+}
+
+export interface ResponseTextFormatParam {
+  type: string;
+  name?: string;
+  schema?: Record<string, unknown>;
+  strict?: boolean;
+  [key: string]: unknown;
+}
+
+export interface ResponseTextConfigParam {
+  format?: ResponseTextFormatParam;
+  [key: string]: unknown;
+}
+
+export interface ResponseInputMessage {
+  role: "user" | "assistant" | "system" | "developer";
+  content: string | Array<Record<string, unknown>>;
+  type?: "message";
+  phase?: "commentary" | "final_answer";
+  [key: string]: unknown;
+}
+
+export type ResponseInput = string | ResponseInputMessage[];
+
+export interface ResponseCreateParams {
+  /**
+   * Text or message inputs for the Agent response.
+   */
+  input: ResponseInput;
+  /**
+   * Responses model. Defaults to "agent".
+   */
+  model?: AgentResponseModel | string;
+  /**
+   * Agent effort configuration. `reasoning.effort` maps to the Agent effort mode.
+   */
+  reasoning?: ResponseReasoningParam | null;
+  instructions?: string | null;
+  previous_response_id?: string | null;
+  metadata?: Record<string, string> | null;
+  text?: ResponseTextConfigParam;
+  stream?: false | null;
+  temperature?: number | null;
+  top_p?: number | null;
+  tools?: Array<Record<string, unknown>>;
+  tool_choice?: unknown;
+  max_output_tokens?: number | null;
+  store?: boolean | null;
+  [key: string]: unknown;
+}
+
+export interface ResponseOutputText {
+  type: "output_text";
+  text: string;
+  annotations: unknown[];
+  [key: string]: unknown;
+}
+
+export interface ResponseOutputMessage {
+  id?: string;
+  type: "message";
+  status: "completed" | "incomplete" | "in_progress";
+  role: "assistant";
+  content: ResponseOutputText[];
+  [key: string]: unknown;
+}
+
+export interface ResponseError {
+  code?: string;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface ResponseIncompleteDetails {
+  reason?: string;
+  [key: string]: unknown;
+}
+
+export interface Response {
+  id: string;
+  object: "response";
+  created_at: number;
+  completed_at?: number | null;
+  status: ResponseStatus;
+  model: string;
+  output: ResponseOutputMessage[];
+  output_text: string;
+  error: ResponseError | null;
+  incomplete_details: ResponseIncompleteDetails | null;
+  instructions: string | null;
+  previous_response_id?: string | null;
+  metadata: Record<string, string> | null;
+  tools: unknown[];
+  tool_choice: unknown;
+  parallel_tool_calls: boolean;
+  temperature: number | null;
+  top_p: number | null;
+  reasoning?: Record<string, unknown> | null;
+  usage?: Record<string, unknown> | null;
+  [key: string]: unknown;
+}

--- a/src/responses/types.ts
+++ b/src/responses/types.ts
@@ -4,7 +4,13 @@
 
 export type AgentResponseModel = "agent" | "exa-agent";
 
-export type AgentResponseEffort = "low" | "medium" | "high" | "xhigh" | "auto";
+export type AgentResponseEffort =
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "auto";
 
 export type ResponseStatus =
   | "completed"

--- a/test/unit/responses.test.ts
+++ b/test/unit/responses.test.ts
@@ -62,7 +62,7 @@ describe("Responses API", () => {
     });
 
     expect(response.output_text).toBe("Returned 1 company.");
-    expect(requestSpy).toHaveBeenCalledWith("/v1/responses", "POST", {
+    expect(requestSpy).toHaveBeenCalledWith("/responses", "POST", {
       input: "Find recent funding rounds.",
       model: "agent",
       reasoning: { effort: "minimal" },

--- a/test/unit/responses.test.ts
+++ b/test/unit/responses.test.ts
@@ -36,7 +36,7 @@ function createMockResponse(): Response {
     parallel_tool_calls: true,
     temperature: 1,
     top_p: 1,
-    reasoning: { effort: "low", summary: null },
+    reasoning: { effort: "minimal", summary: null },
     usage: null,
   };
 }
@@ -56,7 +56,7 @@ describe("Responses API", () => {
 
     const response = await exa.responses.create({
       input: "Find recent funding rounds.",
-      reasoning: { effort: "low" },
+      reasoning: { effort: "minimal" },
       temperature: 0,
       tools: [{ type: "function", name: "ignored_tool" }],
     });
@@ -65,7 +65,7 @@ describe("Responses API", () => {
     expect(requestSpy).toHaveBeenCalledWith("/v1/responses", "POST", {
       input: "Find recent funding rounds.",
       model: "agent",
-      reasoning: { effort: "low" },
+      reasoning: { effort: "minimal" },
       temperature: 0,
       tools: [{ type: "function", name: "ignored_tool" }],
     });

--- a/test/unit/responses.test.ts
+++ b/test/unit/responses.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import Exa from "../../src";
+import { Response } from "../../src/responses";
+
+function createMockResponse(): Response {
+  return {
+    id: "resp_agent_run_123",
+    object: "response",
+    created_at: 1778706660,
+    completed_at: 1778706684,
+    status: "completed",
+    model: "agent",
+    output_text: "Returned 1 company.",
+    output: [
+      {
+        id: "msg_agent_run_123",
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [
+          {
+            type: "output_text",
+            text: "Returned 1 company.",
+            annotations: [],
+          },
+        ],
+      },
+    ],
+    error: null,
+    incomplete_details: null,
+    instructions: null,
+    previous_response_id: null,
+    metadata: {},
+    tools: [],
+    tool_choice: "auto",
+    parallel_tool_calls: true,
+    temperature: 1,
+    top_p: 1,
+    reasoning: { effort: "low", summary: null },
+    usage: null,
+  };
+}
+
+describe("Responses API", () => {
+  it("exposes Responses as a top-level namespace", () => {
+    const exa = new Exa("test-api-key", "https://api.exa.ai");
+
+    expect(exa.responses).toBeDefined();
+  });
+
+  it("creates an Agent response with default model and reasoning effort", async () => {
+    const exa = new Exa("test-api-key", "https://api.exa.ai");
+    const requestSpy = vi
+      .spyOn(exa, "request")
+      .mockResolvedValueOnce(createMockResponse());
+
+    const response = await exa.responses.create({
+      input: "Find recent funding rounds.",
+      reasoning: { effort: "low" },
+      temperature: 0,
+      tools: [{ type: "function", name: "ignored_tool" }],
+    });
+
+    expect(response.output_text).toBe("Returned 1 company.");
+    expect(requestSpy).toHaveBeenCalledWith("/v1/responses", "POST", {
+      input: "Find recent funding rounds.",
+      model: "agent",
+      reasoning: { effort: "low" },
+      temperature: 0,
+      tools: [{ type: "function", name: "ignored_tool" }],
+    });
+  });
+
+  it("rejects streaming Responses requests until streaming is supported", async () => {
+    const exa = new Exa("test-api-key", "https://api.exa.ai");
+    const requestSpy = vi.spyOn(exa, "request");
+
+    await expect(
+      exa.responses.create({
+        input: "Find recent funding rounds.",
+        stream: true as false,
+      })
+    ).rejects.toThrow("Streaming Responses");
+    expect(requestSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a first-class OpenAI-compatible Responses namespace to the TypeScript SDK. Callers can now use `exa.responses.create(...)` to create non-streaming Exa Agent responses through the new `/v1/responses` API surface.

The new surface is intentionally separate from `beta.agent.runs`. It does not require Agent beta headers, defaults `model` to `"agent"`, and follows the OpenAI Responses request shape with fields like `input`, `instructions`, `previous_response_id`, `metadata`, `text`, and `reasoning`.

## Why

The backend now exposes a non-streaming Responses-compatible Agent endpoint. The TypeScript SDK needed an idiomatic wrapper so customers can use the Responses API shape directly from `exa-js` instead of constructing raw HTTP calls or instantiating the OpenAI SDK manually.

## Behavior

`reasoning.effort` maps to Exa Agent effort modes. Supported values are `low`, `medium`, `high`, `xhigh`, and `auto`. Unsupported OpenAI-compatible generation/tool parameters like `temperature`, `top_p`, `tools`, `tool_choice`, and `max_output_tokens` are accepted and forwarded for compatibility; the backend normalizes or ignores them as appropriate.

Streaming is rejected client-side for now because the backend implementation is currently non-streaming.

## Changes

- Adds `src/responses` with a typed `ResponsesClient`.
- Wires `Exa.responses` into the top-level SDK client.
- Re-exports Responses client and request/response types from the package entry point.
- Adds unit coverage for top-level namespace exposure, default `model: "agent"`, `reasoning.effort`, compatible extra params, and streaming rejection.

## Validation

- `npm run test:unit -- test/unit/responses.test.ts test/unit/agent.test.ts`
- `npm run test:unit`
- `npm run build-fast`

Known existing blocker:

- `npm run typecheck` fails on unrelated pre-existing example/websets/search typing errors, not the new Responses files. `build-fast` completed successfully including DTS emit.
