### PR TITLE
Remove Agent beta header requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,10 @@ for await (const chunk of exa.streamAnswer("Explain quantum computing")) {
 }
 ```
 
-## Agent API (Beta)
+## Agent API
 
 ```ts
-const run = await exa.beta.agent.runs.create({
-  betas: ["agent-2026-05-07"],
+const run = await exa.agent.runs.create({
   query:
     "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
   outputSchema: {
@@ -149,9 +148,7 @@ const run = await exa.beta.agent.runs.create({
   effort: "auto",
 });
 
-const completedRun = await exa.beta.agent.runs.pollUntilFinished(run.id, {
-  betas: ["agent-2026-05-07"],
-});
+const completedRun = await exa.agent.runs.pollUntilFinished(run.id);
 console.log(completedRun.output?.structured);
 ```
 

--- a/src/agent/base.ts
+++ b/src/agent/base.ts
@@ -21,49 +21,33 @@ export class AgentBaseClient {
 
   protected async request<T = unknown>(
     endpoint: string,
-    betas: string[],
     method: string = "POST",
     data?: RequestBody,
     params?: QueryParams,
     headers?: Record<string, string>
   ): Promise<T> {
-    if (!betas?.length) {
-      throw new Error("betas must include the Agent API beta identifier");
-    }
-
     return this.client.request<T>(
       `/agent/runs${endpoint}`,
       method,
       data,
       params,
-      {
-        "Exa-Beta": betas.join(","),
-        ...headers,
-      }
+      headers
     );
   }
 
   protected async rawRequest(
     endpoint: string,
-    betas: string[],
     method: string = "POST",
     data?: RequestBody,
     params?: QueryParams,
     headers?: Record<string, string>
   ): Promise<Response> {
-    if (!betas?.length) {
-      throw new Error("betas must include the Agent API beta identifier");
-    }
-
     return this.client.rawRequest(
       `/agent/runs${endpoint}`,
       method,
       data,
       params,
-      {
-        "Exa-Beta": betas.join(","),
-        ...headers,
-      }
+      headers
     );
   }
 

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -23,6 +23,30 @@ import {
 
 type WithBetaOptions<T> = T & AgentBetaOptions;
 
+function headersForBetas(betas?: string[]): Record<string, string> | undefined {
+  const betaValues = betas?.filter(Boolean);
+  if (!betaValues?.length) return undefined;
+  return { "Exa-Beta": betaValues.join(",") };
+}
+
+function buildAgentRunPayload<T>(params: AgentCreateOptions<T>): {
+  stream?: boolean;
+  payload: Record<string, unknown>;
+} {
+  const { stream, outputSchema, ...rest } = params;
+  let schema = outputSchema;
+  if (schema && isZodSchema(schema)) {
+    schema = zodToJsonSchema(schema as ZodSchema<T>);
+  }
+
+  const payload: Record<string, unknown> = { ...rest };
+  if (schema) {
+    payload.outputSchema = schema;
+  }
+
+  return { stream, payload };
+}
+
 async function* streamAgentEvents(
   response: Response
 ): AsyncGenerator<AgentEvent> {
@@ -132,16 +156,7 @@ export class AgentRunsClient extends AgentBaseClient {
   async create<T>(
     params: AgentCreateOptions<T>
   ): Promise<AgentRun | AgentRunTyped<T> | AsyncGenerator<AgentEvent>> {
-    const { stream, outputSchema, ...rest } = params;
-    let schema = outputSchema;
-    if (schema && isZodSchema(schema)) {
-      schema = zodToJsonSchema(schema as ZodSchema<T>);
-    }
-
-    const payload: Record<string, unknown> = { ...rest };
-    if (schema) {
-      payload.outputSchema = schema;
-    }
+    const { stream, payload } = buildAgentRunPayload(params);
 
     if (stream) {
       const response = await this.rawRequest("", "POST", payload, undefined, {
@@ -264,60 +279,237 @@ export class AgentRunsClient extends AgentBaseClient {
 
 export class AgentClient {
   /**
+   * @internal
+   */
+  readonly client: Exa;
+
+  /**
    * Client for Agent runs.
    */
   runs: AgentRunsClient;
 
   constructor(client: Exa) {
+    this.client = client;
     this.runs = new AgentRunsClient(client);
   }
 }
 
-export type AgentBetaClient = AgentClient & {
+export class AgentBetaRunEventsClient extends AgentRunEventsClient {
   /**
-   * @deprecated Use exa.agent.runs instead.
+   * List stored events for an Agent run.
+   *
+   * @deprecated Use exa.agent.runs.events instead.
    */
-  runs: AgentRunsClient & {
-    events: AgentRunEventsClient & {
-      list(
-        runId: string,
-        options?: WithBetaOptions<ListAgentRunEventsParams>
-      ): Promise<ListAgentRunEventsResponse>;
-    };
-    create<T>(
-      params: WithBetaOptions<AgentCreateOptions<T>> & { stream: true }
-    ): Promise<AsyncGenerator<AgentEvent>>;
-    create<T>(
-      params: WithBetaOptions<AgentCreateOptions<T>> & { stream?: false }
-    ): Promise<AgentRunTyped<T>>;
-    create(params: CreateAgentRunParams & AgentBetaOptions): Promise<AgentRun>;
-    get(runId: string, options?: AgentBetaOptions): Promise<AgentRun>;
-    list(
-      options?: WithBetaOptions<ListAgentRunsParams>
-    ): Promise<ListAgentRunsResponse>;
-    listAll(
-      options?: WithBetaOptions<ListAgentRunsParams>
-    ): AsyncGenerator<AgentRun>;
-    getAll(options?: WithBetaOptions<ListAgentRunsParams>): Promise<AgentRun[]>;
-    cancel(runId: string, options?: AgentBetaOptions): Promise<AgentRun>;
-    delete(runId: string, options?: AgentBetaOptions): Promise<DeletedAgentRun>;
-    pollUntilFinished(
-      runId: string,
-      options?: WithBetaOptions<{
-        pollInterval?: number;
-        timeoutMs?: number;
-      }>
-    ): Promise<AgentRun & { status: "completed" | "failed" | "cancelled" }>;
-  };
-};
+  async list(
+    runId: string,
+    options?: WithBetaOptions<ListAgentRunEventsParams>
+  ): Promise<ListAgentRunEventsResponse> {
+    const { betas, ...pagination } = options ?? {};
+    const params = this.buildPaginationParams(pagination);
+    return this.request<ListAgentRunEventsResponse>(
+      `/${runId}/events`,
+      "GET",
+      undefined,
+      params,
+      headersForBetas(betas)
+    );
+  }
+}
+
+export class AgentBetaRunsClient extends AgentRunsClient {
+  /**
+   * @deprecated Use exa.agent.runs.events instead.
+   */
+  events: AgentBetaRunEventsClient;
+
+  constructor(client: Exa) {
+    super(client);
+    this.events = new AgentBetaRunEventsClient(client);
+  }
+
+  async create<T>(
+    params: WithBetaOptions<AgentCreateOptions<T>> & { stream: true }
+  ): Promise<AsyncGenerator<AgentEvent>>;
+  async create<T>(
+    params: WithBetaOptions<AgentCreateOptions<T>> & { stream?: false }
+  ): Promise<AgentRunTyped<T>>;
+  async create(
+    params: CreateAgentRunParams & AgentBetaOptions
+  ): Promise<AgentRun>;
+  async create<T>(
+    params: WithBetaOptions<AgentCreateOptions<T>>
+  ): Promise<AgentRun | AgentRunTyped<T> | AsyncGenerator<AgentEvent>> {
+    const { betas, ...createParams } = params;
+    const { stream, payload } = buildAgentRunPayload(
+      createParams as AgentCreateOptions<T>
+    );
+    const headers = headersForBetas(betas);
+
+    if (stream) {
+      const response = await this.rawRequest("", "POST", payload, undefined, {
+        ...headers,
+        Accept: "text/event-stream",
+      });
+      if (!response.ok) {
+        const message = await response.text();
+        throw new ExaError(
+          message || `Request failed with status code ${response.status}`,
+          response.status,
+          new Date().toISOString(),
+          "/agent/runs"
+        );
+      }
+      return streamAgentEvents(response);
+    }
+
+    return this.request<AgentRunTyped<T>>(
+      "",
+      "POST",
+      payload,
+      undefined,
+      headers
+    );
+  }
+
+  async get(runId: string, options?: AgentBetaOptions): Promise<AgentRun> {
+    return this.request<AgentRun>(
+      `/${runId}`,
+      "GET",
+      undefined,
+      undefined,
+      headersForBetas(options?.betas)
+    );
+  }
+
+  async list(
+    options?: WithBetaOptions<ListAgentRunsParams>
+  ): Promise<ListAgentRunsResponse> {
+    const { betas, ...pagination } = options ?? {};
+    const params = this.buildPaginationParams(pagination);
+    return this.request<ListAgentRunsResponse>(
+      "",
+      "GET",
+      undefined,
+      params,
+      headersForBetas(betas)
+    );
+  }
+
+  async *listAll(
+    options?: WithBetaOptions<ListAgentRunsParams>
+  ): AsyncGenerator<AgentRun> {
+    let cursor: string | undefined = undefined;
+    const { betas, ...pagination } = options ?? {};
+    const pageOptions: ListAgentRunsParams = { ...pagination };
+
+    while (true) {
+      pageOptions.cursor = cursor;
+      const response = await this.list({ ...pageOptions, betas });
+
+      for (const run of response.data) {
+        yield run;
+      }
+
+      if (!response.hasMore || !response.nextCursor) {
+        break;
+      }
+
+      cursor = response.nextCursor;
+    }
+  }
+
+  async getAll(
+    options?: WithBetaOptions<ListAgentRunsParams>
+  ): Promise<AgentRun[]> {
+    const runs: AgentRun[] = [];
+    for await (const run of this.listAll(options)) {
+      runs.push(run);
+    }
+    return runs;
+  }
+
+  async cancel(runId: string, options?: AgentBetaOptions): Promise<AgentRun> {
+    return this.request<AgentRun>(
+      `/${runId}/cancel`,
+      "POST",
+      undefined,
+      undefined,
+      headersForBetas(options?.betas)
+    );
+  }
+
+  async delete(
+    runId: string,
+    options?: AgentBetaOptions
+  ): Promise<DeletedAgentRun> {
+    return this.request<DeletedAgentRun>(
+      `/${runId}`,
+      "DELETE",
+      undefined,
+      undefined,
+      headersForBetas(options?.betas)
+    );
+  }
+
+  async pollUntilFinished(
+    runId: string,
+    options?: WithBetaOptions<{
+      pollInterval?: number;
+      timeoutMs?: number;
+    }>
+  ): Promise<AgentRun & { status: "completed" | "failed" | "cancelled" }> {
+    const pollInterval = options?.pollInterval ?? 1000;
+    const timeoutMs = options?.timeoutMs ?? 60 * 60 * 1000;
+    const startTime = Date.now();
+    const headers = headersForBetas(options?.betas);
+
+    while (true) {
+      const run = await this.request<AgentRun>(
+        `/${runId}`,
+        "GET",
+        undefined,
+        undefined,
+        headers
+      );
+      if (
+        run.status === "completed" ||
+        run.status === "failed" ||
+        run.status === "cancelled"
+      ) {
+        return run as AgentRun & {
+          status: "completed" | "failed" | "cancelled";
+        };
+      }
+
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `Polling timeout: Agent run ${runId} did not complete within ${timeoutMs}ms`
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+  }
+}
 
 /**
  * @deprecated Use AgentClient instead.
  */
-export const AgentBetaClient = AgentClient as unknown as {
-  new (client: Exa): AgentBetaClient;
-  prototype: AgentClient;
-};
+export class AgentBetaClient extends AgentClient {
+  /**
+   * @deprecated Use exa.agent.runs instead.
+   */
+  runs: AgentBetaRunsClient;
+
+  constructor(clientOrAgent: Exa | AgentClient) {
+    const client =
+      clientOrAgent instanceof AgentClient
+        ? clientOrAgent.client
+        : clientOrAgent;
+    super(client);
+    this.runs = new AgentBetaRunsClient(client);
+  }
+}
 
 export class BetaClient {
   /**
@@ -326,10 +518,6 @@ export class BetaClient {
   agent: AgentBetaClient;
 
   constructor(clientOrAgent: Exa | AgentClient) {
-    const agent =
-      clientOrAgent instanceof AgentClient
-        ? clientOrAgent
-        : new AgentClient(clientOrAgent);
-    this.agent = agent as unknown as AgentBetaClient;
+    this.agent = new AgentBetaClient(clientOrAgent);
   }
 }

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -21,6 +21,8 @@ import {
   ListAgentRunsResponse,
 } from "./types";
 
+type WithBetaOptions<T> = T & AgentBetaOptions;
+
 async function* streamAgentEvents(
   response: Response
 ): AsyncGenerator<AgentEvent> {
@@ -94,12 +96,11 @@ export class AgentRunEventsClient extends AgentBaseClient {
    */
   async list(
     runId: string,
-    options: ListAgentRunEventsParams
+    options?: ListAgentRunEventsParams
   ): Promise<ListAgentRunEventsResponse> {
     const params = this.buildPaginationParams(options);
     return this.request<ListAgentRunEventsResponse>(
       `/${runId}/events`,
-      options.betas,
       "GET",
       undefined,
       params
@@ -131,7 +132,7 @@ export class AgentRunsClient extends AgentBaseClient {
   async create<T>(
     params: AgentCreateOptions<T>
   ): Promise<AgentRun | AgentRunTyped<T> | AsyncGenerator<AgentEvent>> {
-    const { stream, outputSchema, betas, ...rest } = params;
+    const { stream, outputSchema, ...rest } = params;
     let schema = outputSchema;
     if (schema && isZodSchema(schema)) {
       schema = zodToJsonSchema(schema as ZodSchema<T>);
@@ -143,16 +144,9 @@ export class AgentRunsClient extends AgentBaseClient {
     }
 
     if (stream) {
-      const response = await this.rawRequest(
-        "",
-        betas,
-        "POST",
-        payload,
-        undefined,
-        {
-          Accept: "text/event-stream",
-        }
-      );
+      const response = await this.rawRequest("", "POST", payload, undefined, {
+        Accept: "text/event-stream",
+      });
       if (!response.ok) {
         const message = await response.text();
         throw new ExaError(
@@ -165,36 +159,30 @@ export class AgentRunsClient extends AgentBaseClient {
       return streamAgentEvents(response);
     }
 
-    return this.request<AgentRunTyped<T>>("", betas, "POST", payload);
+    return this.request<AgentRunTyped<T>>("", "POST", payload);
   }
 
   /**
    * Get an Agent run by ID.
    */
-  async get(runId: string, options: AgentBetaOptions): Promise<AgentRun> {
-    return this.request<AgentRun>(`/${runId}`, options.betas, "GET");
+  async get(runId: string): Promise<AgentRun> {
+    return this.request<AgentRun>(`/${runId}`, "GET");
   }
 
   /**
    * List Agent runs.
    */
-  async list(options: ListAgentRunsParams): Promise<ListAgentRunsResponse> {
+  async list(options?: ListAgentRunsParams): Promise<ListAgentRunsResponse> {
     const params = this.buildPaginationParams(options);
-    return this.request<ListAgentRunsResponse>(
-      "",
-      options.betas,
-      "GET",
-      undefined,
-      params
-    );
+    return this.request<ListAgentRunsResponse>("", "GET", undefined, params);
   }
 
   /**
    * Iterate through all Agent runs, handling pagination automatically.
    */
-  async *listAll(options: ListAgentRunsParams): AsyncGenerator<AgentRun> {
+  async *listAll(options?: ListAgentRunsParams): AsyncGenerator<AgentRun> {
     let cursor: string | undefined = undefined;
-    const pageOptions = { ...options };
+    const pageOptions = options ? { ...options } : {};
 
     while (true) {
       pageOptions.cursor = cursor;
@@ -215,7 +203,7 @@ export class AgentRunsClient extends AgentBaseClient {
   /**
    * Collect all Agent runs into an array.
    */
-  async getAll(options: ListAgentRunsParams): Promise<AgentRun[]> {
+  async getAll(options?: ListAgentRunsParams): Promise<AgentRun[]> {
     const runs: AgentRun[] = [];
     for await (const run of this.listAll(options)) {
       runs.push(run);
@@ -226,18 +214,15 @@ export class AgentRunsClient extends AgentBaseClient {
   /**
    * Cancel a queued or running Agent run.
    */
-  async cancel(runId: string, options: AgentBetaOptions): Promise<AgentRun> {
-    return this.request<AgentRun>(`/${runId}/cancel`, options.betas, "POST");
+  async cancel(runId: string): Promise<AgentRun> {
+    return this.request<AgentRun>(`/${runId}/cancel`, "POST");
   }
 
   /**
    * Delete a stored Agent run.
    */
-  async delete(
-    runId: string,
-    options: AgentBetaOptions
-  ): Promise<DeletedAgentRun> {
-    return this.request<DeletedAgentRun>(`/${runId}`, options.betas, "DELETE");
+  async delete(runId: string): Promise<DeletedAgentRun> {
+    return this.request<DeletedAgentRun>(`/${runId}`, "DELETE");
   }
 
   /**
@@ -245,7 +230,7 @@ export class AgentRunsClient extends AgentBaseClient {
    */
   async pollUntilFinished(
     runId: string,
-    options: AgentBetaOptions & {
+    options?: {
       pollInterval?: number;
       timeoutMs?: number;
     }
@@ -255,7 +240,7 @@ export class AgentRunsClient extends AgentBaseClient {
     const startTime = Date.now();
 
     while (true) {
-      const run = await this.get(runId, { betas: options.betas });
+      const run = await this.get(runId);
       if (
         run.status === "completed" ||
         run.status === "failed" ||
@@ -277,7 +262,7 @@ export class AgentRunsClient extends AgentBaseClient {
   }
 }
 
-export class AgentBetaClient {
+export class AgentClient {
   /**
    * Client for Agent runs.
    */
@@ -288,13 +273,63 @@ export class AgentBetaClient {
   }
 }
 
+export type AgentBetaClient = AgentClient & {
+  /**
+   * @deprecated Use exa.agent.runs instead.
+   */
+  runs: AgentRunsClient & {
+    events: AgentRunEventsClient & {
+      list(
+        runId: string,
+        options?: WithBetaOptions<ListAgentRunEventsParams>
+      ): Promise<ListAgentRunEventsResponse>;
+    };
+    create<T>(
+      params: WithBetaOptions<AgentCreateOptions<T>> & { stream: true }
+    ): Promise<AsyncGenerator<AgentEvent>>;
+    create<T>(
+      params: WithBetaOptions<AgentCreateOptions<T>> & { stream?: false }
+    ): Promise<AgentRunTyped<T>>;
+    create(params: CreateAgentRunParams & AgentBetaOptions): Promise<AgentRun>;
+    get(runId: string, options?: AgentBetaOptions): Promise<AgentRun>;
+    list(
+      options?: WithBetaOptions<ListAgentRunsParams>
+    ): Promise<ListAgentRunsResponse>;
+    listAll(
+      options?: WithBetaOptions<ListAgentRunsParams>
+    ): AsyncGenerator<AgentRun>;
+    getAll(options?: WithBetaOptions<ListAgentRunsParams>): Promise<AgentRun[]>;
+    cancel(runId: string, options?: AgentBetaOptions): Promise<AgentRun>;
+    delete(runId: string, options?: AgentBetaOptions): Promise<DeletedAgentRun>;
+    pollUntilFinished(
+      runId: string,
+      options?: WithBetaOptions<{
+        pollInterval?: number;
+        timeoutMs?: number;
+      }>
+    ): Promise<AgentRun & { status: "completed" | "failed" | "cancelled" }>;
+  };
+};
+
+/**
+ * @deprecated Use AgentClient instead.
+ */
+export const AgentBetaClient = AgentClient as unknown as {
+  new (client: Exa): AgentBetaClient;
+  prototype: AgentClient;
+};
+
 export class BetaClient {
   /**
-   * Beta Agent namespace.
+   * @deprecated Use exa.agent instead.
    */
   agent: AgentBetaClient;
 
-  constructor(client: Exa) {
-    this.agent = new AgentBetaClient(client);
+  constructor(clientOrAgent: Exa | AgentClient) {
+    const agent =
+      clientOrAgent instanceof AgentClient
+        ? clientOrAgent
+        : new AgentClient(clientOrAgent);
+    this.agent = agent as unknown as AgentBetaClient;
   }
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -3,6 +3,7 @@
  */
 
 export {
+  AgentClient,
   AgentBetaClient,
   AgentRunsClient,
   AgentRunEventsClient,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -4,10 +4,16 @@
 
 import { ZodSchema } from "zod";
 
+/**
+ * @deprecated Agent API beta header is no longer required by the SDK.
+ */
 export const AGENT_BETA_HEADER = "agent-2026-05-07";
 
 export interface AgentBetaOptions {
-  betas: string[];
+  /**
+   * @deprecated Agent API beta header is no longer required by the SDK.
+   */
+  betas?: string[];
 }
 
 export type AgentRunStatus =
@@ -101,7 +107,7 @@ export type AgentRunTyped<T> = Omit<AgentRun, "output"> & {
   output?: (Omit<AgentOutput, "structured"> & { structured?: T }) | null;
 };
 
-export interface ListAgentRunsParams extends AgentBetaOptions {
+export interface ListAgentRunsParams {
   cursor?: string;
   limit?: number;
 }
@@ -127,7 +133,7 @@ export interface AgentEvent {
   [key: string]: unknown;
 }
 
-export interface ListAgentRunEventsParams extends AgentBetaOptions {
+export interface ListAgentRunEventsParams {
   cursor?: string;
   limit?: number;
 }
@@ -140,7 +146,6 @@ export interface ListAgentRunEventsResponse {
 }
 
 export interface CreateAgentRunParams {
-  betas: string[];
   query: string;
   systemPrompt?: string;
   input?: AgentInput;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -5,13 +5,15 @@
 import { ZodSchema } from "zod";
 
 /**
- * @deprecated Agent API beta header is no longer required by the SDK.
+ * @deprecated Agent API beta header is no longer required for `exa.agent`.
+ * Retained for legacy `exa.beta.agent` compatibility.
  */
 export const AGENT_BETA_HEADER = "agent-2026-05-07";
 
 export interface AgentBetaOptions {
   /**
-   * @deprecated Agent API beta header is no longer required by the SDK.
+   * @deprecated Agent API beta header is no longer required for `exa.agent`.
+   * Values supplied to `exa.beta.agent` are sent as the `Exa-Beta` header.
    */
   betas?: string[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import fetch, { Headers } from "cross-fetch";
 import { ZodSchema } from "zod";
 import packageJson from "../package.json";
-import { BetaClient } from "./agent/client";
+import { AgentClient, BetaClient } from "./agent/client";
 import { ExaError, HttpStatusCode } from "./errors";
 import { SearchMonitorsClient } from "./monitors/client";
 import { ResearchClient } from "./research/client";
@@ -727,6 +727,11 @@ export class Exa {
   monitors: SearchMonitorsClient;
 
   /**
+   * Agent API client
+   */
+  agent: AgentClient;
+
+  /**
    * Beta API clients
    */
   beta: BetaClient;
@@ -860,8 +865,10 @@ export class Exa {
     this.research = new ResearchClient(this);
     // Initialize the Search Monitors client
     this.monitors = new SearchMonitorsClient(this);
+    // Initialize the Agent client
+    this.agent = new AgentClient(this);
     // Initialize beta clients
-    this.beta = new BetaClient(this);
+    this.beta = new BetaClient(this.agent);
   }
 
   /**

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import Exa from "../../src";
-import { AGENT_BETA_HEADER } from "../../src/agent";
+import {
+  AgentBetaClient,
+  AgentClient,
+  AGENT_BETA_HEADER,
+  BetaClient,
+} from "../../src/agent";
 import {
   AgentRun,
   DeletedAgentRun,
@@ -9,8 +14,6 @@ import {
   ListAgentRunsResponse,
 } from "../../src/agent/types";
 import { getProtectedClient } from "./helpers";
-
-const AGENT_BETAS = [AGENT_BETA_HEADER];
 
 function createSseResponse(chunks: string[]): Response {
   const stream = new ReadableStream({
@@ -61,21 +64,46 @@ describe("Agent API", () => {
     vi.unstubAllGlobals();
   });
 
-  it("exposes Agent runs under the beta namespace", () => {
-    expect(exa.beta.agent.runs).toBeDefined();
-    expect((exa.beta.agent as any).run).toBeUndefined();
-    expect((exa as any).agent).toBeUndefined();
+  it("exposes Agent runs under the primary namespace", () => {
+    expect(exa.agent.runs).toBeDefined();
+    expect((exa.agent as any).run).toBeUndefined();
   });
 
-  it("creates an Agent run with explicit beta headers", async () => {
+  it("keeps the beta Agent namespace as an alias", () => {
+    expect(AgentBetaClient).toBe(AgentClient);
+    expect(exa.agent).toBeInstanceOf(AgentBetaClient);
+    expect(exa.beta.agent).toBe(exa.agent);
+    expect(exa.beta.agent.runs).toBe(exa.agent.runs);
+    expect(new AgentBetaClient(exa).runs).toBeDefined();
+    expect(new BetaClient(exa).agent.runs).toBeDefined();
+
+    if (false) {
+      // @ts-expect-error betas are only accepted through exa.beta.agent.
+      exa.agent.runs.create({ query: "Find companies.", betas: [] });
+      exa.beta.agent.runs.create({
+        query: "Find companies.",
+        betas: [AGENT_BETA_HEADER],
+      });
+      // @ts-expect-error betas are only accepted through exa.beta.agent.
+      exa.agent.runs.get("agent_run_123", { betas: [] });
+      exa.beta.agent.runs.get("agent_run_123", {
+        betas: [AGENT_BETA_HEADER],
+      });
+      new AgentBetaClient(exa).runs.create({
+        query: "Find companies.",
+        betas: [AGENT_BETA_HEADER],
+      });
+    }
+  });
+
+  it("creates an Agent run without beta headers", async () => {
     const mockResponse = createMockRun();
-    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce(mockResponse);
 
     const params = {
-      betas: AGENT_BETAS,
       query: "Find recent funding rounds.",
       systemPrompt: "Prefer primary sources.",
       input: { data: [{ company: "Example AI" }] },
@@ -83,58 +111,53 @@ describe("Agent API", () => {
       effort: "high" as const,
       metadata: { workflow: "funding-watch" },
     };
-    const result = await exa.beta.agent.runs.create(params);
+    const result = await exa.agent.runs.create(params);
 
-    const { betas, ...payload } = params;
-    expect(requestSpy).toHaveBeenCalledWith("", betas, "POST", payload);
+    expect(requestSpy).toHaveBeenCalledWith("", "POST", params);
     expect(result).toEqual(mockResponse);
   });
 
-  it("requires explicit betas for Agent calls", async () => {
-    await expect(
-      exa.beta.agent.runs.create({
-        betas: [],
-        query: "Find recent funding rounds.",
-      })
-    ).rejects.toThrow("betas");
-  });
-
-  it("requires explicit betas for plain JavaScript callers", async () => {
-    await expect(
-      (exa.beta.agent.runs as any).create({
-        query: "Find recent funding rounds.",
-      })
-    ).rejects.toThrow("betas");
-  });
-
-  it("converts zod output schemas before creating an Agent run", async () => {
-    const runClient = getProtectedClient(exa.beta.agent.runs);
+  it("passes legacy betas through when creating an Agent run from the beta namespace", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce(createMockRun());
 
     await exa.beta.agent.runs.create({
-      betas: AGENT_BETAS,
+      betas: [AGENT_BETA_HEADER],
+      query: "Find recent funding rounds.",
+    });
+
+    const payload = requestSpy.mock.calls[0][2] as Record<string, any>;
+    expect(payload.betas).toEqual([AGENT_BETA_HEADER]);
+  });
+
+  it("converts zod output schemas before creating an Agent run", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(createMockRun());
+
+    await exa.agent.runs.create({
       query: "Find recent funding rounds.",
       outputSchema: z.object({
         companyName: z.string(),
       }),
     });
 
-    const payload = requestSpy.mock.calls[0][3] as Record<string, any>;
+    const payload = requestSpy.mock.calls[0][2] as Record<string, any>;
     expect(payload.outputSchema.type).toBe("object");
     expect(payload.outputSchema.properties.companyName.type).toBe("string");
     expect(payload.betas).toBeUndefined();
   });
 
   it("accepts contact fields in output schemas", async () => {
-    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce(createMockRun());
 
-    await exa.beta.agent.runs.create({
-      betas: AGENT_BETAS,
+    await exa.agent.runs.create({
       query:
         "Find people at AI infrastructure companies and return work emails when available.",
       outputSchema: {
@@ -156,7 +179,7 @@ describe("Agent API", () => {
       },
     });
 
-    const payload = requestSpy.mock.calls[0][3] as Record<string, any>;
+    const payload = requestSpy.mock.calls[0][2] as Record<string, any>;
     expect(payload.outputSchema.properties.people.maxItems).toBe(10);
     expect(
       payload.outputSchema.properties.people.items.properties.contact_email
@@ -165,19 +188,19 @@ describe("Agent API", () => {
     expect(payload.enrichments).toBeUndefined();
   });
 
-  it("base client injects caller-provided beta headers", async () => {
+  it("base client does not inject beta headers", async () => {
     const requestSpy = vi
       .spyOn(exa, "request")
       .mockResolvedValueOnce(createMockRun());
 
-    await exa.beta.agent.runs.get("agent_run_123", { betas: AGENT_BETAS });
+    await exa.agent.runs.get("agent_run_123");
 
     expect(requestSpy).toHaveBeenCalledWith(
       "/agent/runs/agent_run_123",
       "GET",
       undefined,
       undefined,
-      { "Exa-Beta": AGENT_BETA_HEADER }
+      undefined
     );
   });
 
@@ -188,24 +211,21 @@ describe("Agent API", () => {
       hasMore: false,
       nextCursor: null,
     };
-    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce(mockResponse);
 
-    const result = await exa.beta.agent.runs.list({
-      betas: AGENT_BETAS,
-      limit: 10,
-    });
+    const result = await exa.agent.runs.list({ limit: 10 });
 
-    expect(requestSpy).toHaveBeenCalledWith("", AGENT_BETAS, "GET", undefined, {
+    expect(requestSpy).toHaveBeenCalledWith("", "GET", undefined, {
       limit: 10,
     });
     expect(result).toEqual(mockResponse);
   });
 
   it("paginates through Agent runs with listAll and getAll", async () => {
-    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce({
@@ -228,41 +248,25 @@ describe("Agent API", () => {
       });
 
     const listed = [];
-    for await (const run of exa.beta.agent.runs.listAll({
-      betas: AGENT_BETAS,
+    for await (const run of exa.agent.runs.listAll({
       limit: 1,
     })) {
       listed.push(run.id);
     }
-    const collected = await exa.beta.agent.runs.getAll({
-      betas: AGENT_BETAS,
+    const collected = await exa.agent.runs.getAll({
       limit: 1,
     });
 
     expect(listed).toEqual(["agent_run_1", "agent_run_2"]);
     expect(collected.map((run) => run.id)).toEqual(["agent_run_3"]);
-    expect(requestSpy).toHaveBeenNthCalledWith(
-      1,
-      "",
-      AGENT_BETAS,
-      "GET",
-      undefined,
-      {
-        limit: 1,
-        cursor: undefined,
-      }
-    );
-    expect(requestSpy).toHaveBeenNthCalledWith(
-      2,
-      "",
-      AGENT_BETAS,
-      "GET",
-      undefined,
-      {
-        limit: 1,
-        cursor: "cursor_2",
-      }
-    );
+    expect(requestSpy).toHaveBeenNthCalledWith(1, "", "GET", undefined, {
+      limit: 1,
+      cursor: undefined,
+    });
+    expect(requestSpy).toHaveBeenNthCalledWith(2, "", "GET", undefined, {
+      limit: 1,
+      cursor: "cursor_2",
+    });
   });
 
   it("cancels and deletes Agent runs", async () => {
@@ -276,30 +280,20 @@ describe("Agent API", () => {
       object: "agent_run.deleted",
       deleted: true,
     };
-    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce(cancelled)
       .mockResolvedValueOnce(deleted);
 
-    expect(
-      await exa.beta.agent.runs.cancel("agent_run_123", { betas: AGENT_BETAS })
-    ).toEqual(cancelled);
-    expect(
-      await exa.beta.agent.runs.delete("agent_run_123", { betas: AGENT_BETAS })
-    ).toEqual(deleted);
+    expect(await exa.agent.runs.cancel("agent_run_123")).toEqual(cancelled);
+    expect(await exa.agent.runs.delete("agent_run_123")).toEqual(deleted);
     expect(requestSpy).toHaveBeenNthCalledWith(
       1,
       "/agent_run_123/cancel",
-      AGENT_BETAS,
       "POST"
     );
-    expect(requestSpy).toHaveBeenNthCalledWith(
-      2,
-      "/agent_run_123",
-      AGENT_BETAS,
-      "DELETE"
-    );
+    expect(requestSpy).toHaveBeenNthCalledWith(2, "/agent_run_123", "DELETE");
   });
 
   it("lists Agent run events", async () => {
@@ -316,19 +310,17 @@ describe("Agent API", () => {
       hasMore: false,
       nextCursor: null,
     };
-    const eventsClient = getProtectedClient(exa.beta.agent.runs.events);
+    const eventsClient = getProtectedClient(exa.agent.runs.events);
     const requestSpy = vi
       .spyOn(eventsClient, "request")
       .mockResolvedValueOnce(mockResponse);
 
-    const result = await exa.beta.agent.runs.events.list("agent_run_123", {
-      betas: AGENT_BETAS,
+    const result = await exa.agent.runs.events.list("agent_run_123", {
       limit: 20,
     });
 
     expect(requestSpy).toHaveBeenCalledWith(
       "/agent_run_123/events",
-      AGENT_BETAS,
       "GET",
       undefined,
       { limit: 20 }
@@ -344,8 +336,7 @@ describe("Agent API", () => {
       .spyOn(exa, "rawRequest")
       .mockResolvedValueOnce(response);
 
-    const events = await exa.beta.agent.runs.create({
-      betas: AGENT_BETAS,
+    const events = await exa.agent.runs.create({
       query: "Find companies.",
       stream: true,
     });
@@ -363,7 +354,6 @@ describe("Agent API", () => {
       { query: "Find companies." },
       undefined,
       {
-        "Exa-Beta": AGENT_BETA_HEADER,
         Accept: "text/event-stream",
       }
     );
@@ -378,16 +368,15 @@ describe("Agent API", () => {
 
   it("throws when streaming Agent run creation returns an error", async () => {
     vi.spyOn(exa, "rawRequest").mockResolvedValueOnce(
-      new Response("beta header missing", { status: 400 })
+      new Response("stream request failed", { status: 400 })
     );
 
     await expect(
-      exa.beta.agent.runs.create({
-        betas: AGENT_BETAS,
+      exa.agent.runs.create({
         query: "Find companies.",
         stream: true,
       })
-    ).rejects.toThrow("beta header missing");
+    ).rejects.toThrow("stream request failed");
   });
 
   it("cancels streaming Agent responses when callers stop early", async () => {
@@ -406,8 +395,7 @@ describe("Agent API", () => {
     );
     vi.spyOn(exa, "rawRequest").mockResolvedValueOnce(response);
 
-    const events = await exa.beta.agent.runs.create({
-      betas: AGENT_BETAS,
+    const events = await exa.agent.runs.create({
       query: "Find companies.",
       stream: true,
     });
@@ -423,18 +411,14 @@ describe("Agent API", () => {
   it("polls until an Agent run reaches a terminal status", async () => {
     vi.useFakeTimers();
     const getSpy = vi
-      .spyOn(exa.beta.agent.runs, "get")
+      .spyOn(exa.agent.runs, "get")
       .mockResolvedValueOnce({ ...createMockRun(), status: "running" })
       .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
 
-    const resultPromise = exa.beta.agent.runs.pollUntilFinished(
-      "agent_run_123",
-      {
-        betas: AGENT_BETAS,
-        pollInterval: 5,
-        timeoutMs: 1000,
-      }
-    );
+    const resultPromise = exa.agent.runs.pollUntilFinished("agent_run_123", {
+      pollInterval: 5,
+      timeoutMs: 1000,
+    });
 
     await vi.advanceTimersByTimeAsync(5);
 
@@ -447,19 +431,15 @@ describe("Agent API", () => {
 
   it("throws when Agent polling times out", async () => {
     vi.useFakeTimers();
-    vi.spyOn(exa.beta.agent.runs, "get").mockResolvedValue({
+    vi.spyOn(exa.agent.runs, "get").mockResolvedValue({
       ...createMockRun(),
       status: "running",
     });
 
-    const resultPromise = exa.beta.agent.runs.pollUntilFinished(
-      "agent_run_123",
-      {
-        betas: AGENT_BETAS,
-        pollInterval: 5,
-        timeoutMs: 1,
-      }
-    );
+    const resultPromise = exa.agent.runs.pollUntilFinished("agent_run_123", {
+      pollInterval: 5,
+      timeoutMs: 1,
+    });
     const rejection = expect(resultPromise).rejects.toThrow(
       "Agent run agent_run_123 did not complete within 1ms"
     );
@@ -482,7 +462,6 @@ describe("Agent API", () => {
       { query: "Find companies." },
       undefined,
       {
-        "Exa-Beta": AGENT_BETA_HEADER,
         Accept: "text/event-stream",
       }
     );
@@ -491,7 +470,7 @@ describe("Agent API", () => {
     const headers = init.headers as Record<string, string>;
     expect(headers["x-api-key"]).toBe("test-api-key");
     expect(headers["content-type"]).toBe("application/json");
-    expect(headers["Exa-Beta"]).toBe(AGENT_BETA_HEADER);
+    expect(headers["Exa-Beta"]).toBeUndefined();
     expect(headers.Accept).toBe("text/event-stream");
   });
 });

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -69,13 +69,17 @@ describe("Agent API", () => {
     expect((exa.agent as any).run).toBeUndefined();
   });
 
-  it("keeps the beta Agent namespace as an alias", () => {
-    expect(AgentBetaClient).toBe(AgentClient);
-    expect(exa.agent).toBeInstanceOf(AgentBetaClient);
-    expect(exa.beta.agent).toBe(exa.agent);
-    expect(exa.beta.agent.runs).toBe(exa.agent.runs);
+  it("keeps the beta Agent namespace as a compatibility wrapper", () => {
+    expect(AgentBetaClient).not.toBe(AgentClient);
+    expect(exa.agent).toBeInstanceOf(AgentClient);
+    expect(exa.beta.agent).toBeInstanceOf(AgentBetaClient);
+    expect(exa.beta.agent).toBeInstanceOf(AgentClient);
+    expect(exa.beta.agent).not.toBe(exa.agent);
+    expect(exa.beta.agent.runs).not.toBe(exa.agent.runs);
     expect(new AgentBetaClient(exa).runs).toBeDefined();
+    expect(new AgentBetaClient(exa.agent).runs).toBeDefined();
     expect(new BetaClient(exa).agent.runs).toBeDefined();
+    expect(new BetaClient(exa.agent).agent.runs).toBeDefined();
 
     if (false) {
       // @ts-expect-error betas are only accepted through exa.beta.agent.
@@ -117,8 +121,8 @@ describe("Agent API", () => {
     expect(result).toEqual(mockResponse);
   });
 
-  it("passes legacy betas through when creating an Agent run from the beta namespace", async () => {
-    const runClient = getProtectedClient(exa.agent.runs);
+  it("sends legacy beta values as headers when creating an Agent run from the beta namespace", async () => {
+    const runClient = getProtectedClient(exa.beta.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
       .mockResolvedValueOnce(createMockRun());
@@ -129,7 +133,34 @@ describe("Agent API", () => {
     });
 
     const payload = requestSpy.mock.calls[0][2] as Record<string, any>;
-    expect(payload.betas).toEqual([AGENT_BETA_HEADER]);
+    expect(payload).toEqual({ query: "Find recent funding rounds." });
+    expect(requestSpy).toHaveBeenCalledWith(
+      "",
+      "POST",
+      { query: "Find recent funding rounds." },
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+  });
+
+  it("omits legacy beta headers when beta values are empty", async () => {
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(createMockRun());
+
+    await exa.beta.agent.runs.create({
+      betas: [],
+      query: "Find recent funding rounds.",
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      "",
+      "POST",
+      { query: "Find recent funding rounds." },
+      undefined,
+      undefined
+    );
   });
 
   it("converts zod output schemas before creating an Agent run", async () => {
@@ -224,6 +255,33 @@ describe("Agent API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("lists Agent runs with legacy beta headers from the beta namespace", async () => {
+    const mockResponse: ListAgentRunsResponse = {
+      object: "list",
+      data: [createMockRun()],
+      hasMore: false,
+      nextCursor: null,
+    };
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.beta.agent.runs.list({
+      betas: [AGENT_BETA_HEADER],
+      limit: 10,
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      "",
+      "GET",
+      undefined,
+      { limit: 10 },
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(result).toEqual(mockResponse);
+  });
+
   it("paginates through Agent runs with listAll and getAll", async () => {
     const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
@@ -269,6 +327,56 @@ describe("Agent API", () => {
     });
   });
 
+  it("preserves legacy beta headers while paginating through the beta namespace", async () => {
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce({
+        object: "list",
+        data: [{ ...createMockRun(), id: "agent_run_1" }],
+        hasMore: true,
+        nextCursor: "cursor_2",
+      })
+      .mockResolvedValueOnce({
+        object: "list",
+        data: [{ ...createMockRun(), id: "agent_run_2" }],
+        hasMore: false,
+        nextCursor: null,
+      });
+
+    const listed = [];
+    for await (const run of exa.beta.agent.runs.listAll({
+      betas: [AGENT_BETA_HEADER],
+      limit: 1,
+    })) {
+      listed.push(run.id);
+    }
+
+    expect(listed).toEqual(["agent_run_1", "agent_run_2"]);
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      1,
+      "",
+      "GET",
+      undefined,
+      {
+        limit: 1,
+        cursor: undefined,
+      },
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      2,
+      "",
+      "GET",
+      undefined,
+      {
+        limit: 1,
+        cursor: "cursor_2",
+      },
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+  });
+
   it("cancels and deletes Agent runs", async () => {
     const cancelled: AgentRun = {
       ...createMockRun(),
@@ -294,6 +402,60 @@ describe("Agent API", () => {
       "POST"
     );
     expect(requestSpy).toHaveBeenNthCalledWith(2, "/agent_run_123", "DELETE");
+  });
+
+  it("gets, cancels, and deletes Agent runs with legacy beta headers from the beta namespace", async () => {
+    const cancelled: AgentRun = {
+      ...createMockRun(),
+      status: "cancelled",
+      stopReason: "cancelled",
+    };
+    const deleted: DeletedAgentRun = {
+      id: "agent_run_123",
+      object: "agent_run.deleted",
+      deleted: true,
+    };
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(createMockRun())
+      .mockResolvedValueOnce(cancelled)
+      .mockResolvedValueOnce(deleted);
+
+    await exa.beta.agent.runs.get("agent_run_123", {
+      betas: [AGENT_BETA_HEADER],
+    });
+    await exa.beta.agent.runs.cancel("agent_run_123", {
+      betas: [AGENT_BETA_HEADER],
+    });
+    await exa.beta.agent.runs.delete("agent_run_123", {
+      betas: [AGENT_BETA_HEADER],
+    });
+
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      1,
+      "/agent_run_123",
+      "GET",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      2,
+      "/agent_run_123/cancel",
+      "POST",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      3,
+      "/agent_run_123",
+      "DELETE",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
   });
 
   it("lists Agent run events", async () => {
@@ -328,6 +490,40 @@ describe("Agent API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("lists Agent run events with legacy beta headers from the beta namespace", async () => {
+    const mockResponse: ListAgentRunEventsResponse = {
+      object: "list",
+      data: [
+        {
+          id: "1",
+          event: "agent_run.created",
+          data: { id: "agent_run_123", status: "queued" },
+          createdAt: "2026-05-07T18:31:00.000Z",
+        },
+      ],
+      hasMore: false,
+      nextCursor: null,
+    };
+    const eventsClient = getProtectedClient(exa.beta.agent.runs.events);
+    const requestSpy = vi
+      .spyOn(eventsClient, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.beta.agent.runs.events.list("agent_run_123", {
+      betas: [AGENT_BETA_HEADER],
+      limit: 20,
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      "/agent_run_123/events",
+      "GET",
+      undefined,
+      { limit: 20 },
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(result).toEqual(mockResponse);
+  });
+
   it("streams created Agent run events with SSE headers", async () => {
     const response = createSseResponse([
       'id: 1\nevent: agent_run.created\ndata: {"id":"agent_run_123","status":"queued"}\n\n',
@@ -354,6 +550,46 @@ describe("Agent API", () => {
       { query: "Find companies." },
       undefined,
       {
+        Accept: "text/event-stream",
+      }
+    );
+    expect(collected).toEqual([
+      {
+        id: "1",
+        event: "agent_run.created",
+        data: { id: "agent_run_123", status: "queued" },
+      },
+    ]);
+  });
+
+  it("streams created Agent run events with SSE and legacy beta headers from the beta namespace", async () => {
+    const response = createSseResponse([
+      'id: 1\nevent: agent_run.created\ndata: {"id":"agent_run_123","status":"queued"}\n\n',
+    ]);
+    const rawRequestSpy = vi
+      .spyOn(exa, "rawRequest")
+      .mockResolvedValueOnce(response);
+
+    const events = await exa.beta.agent.runs.create({
+      betas: [AGENT_BETA_HEADER],
+      query: "Find companies.",
+      stream: true,
+    });
+
+    const collected = [];
+    for await (const event of events) {
+      collected.push(event);
+    }
+    const reader = response.body?.getReader();
+    reader?.releaseLock();
+
+    expect(rawRequestSpy).toHaveBeenCalledWith(
+      "/agent/runs",
+      "POST",
+      { query: "Find companies." },
+      undefined,
+      {
+        "Exa-Beta": AGENT_BETA_HEADER,
         Accept: "text/event-stream",
       }
     );
@@ -427,6 +663,47 @@ describe("Agent API", () => {
       status: "completed",
     });
     expect(getSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("polls with legacy beta headers from the beta namespace", async () => {
+    vi.useFakeTimers();
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "running" })
+      .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
+
+    const resultPromise = exa.beta.agent.runs.pollUntilFinished(
+      "agent_run_123",
+      {
+        betas: [AGENT_BETA_HEADER],
+        pollInterval: 5,
+        timeoutMs: 1000,
+      }
+    );
+
+    await vi.advanceTimersByTimeAsync(5);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      id: "agent_run_123",
+      status: "completed",
+    });
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      1,
+      "/agent_run_123",
+      "GET",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      2,
+      "/agent_run_123",
+      "GET",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
   });
 
   it("throws when Agent polling times out", async () => {

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -2,7 +2,12 @@ import {
   SearchMonitorRunsClient,
   SearchMonitorsClient,
 } from "../../src/monitors/client";
-import { AgentRunsClient, AgentRunEventsClient } from "../../src/agent/client";
+import {
+  AgentBetaRunEventsClient,
+  AgentBetaRunsClient,
+  AgentRunsClient,
+  AgentRunEventsClient,
+} from "../../src/agent/client";
 import { WebsetsBaseClient } from "../../src/websets/base";
 import { WebsetsClient } from "../../src/websets/client";
 import { WebsetEnrichmentsClient } from "../../src/websets/enrichments";
@@ -39,6 +44,8 @@ export function getProtectedClient<
     | EventsClient
     | SearchMonitorsClient
     | SearchMonitorRunsClient
+    | AgentBetaRunsClient
+    | AgentBetaRunEventsClient
     | AgentRunsClient
     | AgentRunEventsClient,
 >(client: T): WithProtectedAccess<T> {
@@ -60,6 +67,8 @@ export function getProtectedClientInstance(
     | EventsClient
     | SearchMonitorsClient
     | SearchMonitorRunsClient
+    | AgentBetaRunsClient
+    | AgentBetaRunEventsClient
     | AgentRunsClient
     | AgentRunEventsClient
 ) {


### PR DESCRIPTION
## Summary
- add `exa.agent` as the primary Agent API namespace while keeping `exa.beta.agent` as a deprecated alias
- remove the SDK requirement to provide Agent beta headers and stop injecting the `Exa-Beta` header
- preserve compatibility for `AgentBetaClient`, `BetaClient`, `AGENT_BETA_HEADER`, and legacy `betas` params on the beta namespace

## Testing
- npx vitest run test/unit/agent.test.ts
- npx tsc --noEmit --target es2020 --module esnext --moduleResolution node --strict --esModuleInterop --skipLibCheck --resolveJsonModule --types vitest/globals src/index.ts src/agent/base.ts src/agent/client.ts src/agent/types.ts src/agent/index.ts test/unit/agent.test.ts
- npm run build
- git diff --check
