### PR TITLE
[codex] Bump exa-js version to 2.14.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "exa-js",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "exa-js",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "~4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exa-js",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "description": "Exa SDK for Node.js and the browser",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

Bumps the exa-js package version to 2.14.0 after the agent API beta header requirement was removed from master.

Updated version metadata in:
- package.json
- package-lock.json

## Validation

- `npm run test:unit` passed: 13 files, 127 tests
