### PR TITLE
[codex] Add minimal Agent effort option

### DIFF
--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -33,7 +33,13 @@ export type AgentStopReason =
 
 export type AgentConfidence = "low" | "medium" | "high";
 
-export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "auto";
+export type AgentEffort =
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "auto";
 
 export interface AgentInput {
   data?: Record<string, unknown>[];

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -112,7 +112,7 @@ describe("Agent API", () => {
       systemPrompt: "Prefer primary sources.",
       input: { data: [{ company: "Example AI" }] },
       outputSchema: { type: "object" as const },
-      effort: "high" as const,
+      effort: "minimal" as const,
       metadata: { workflow: "funding-watch" },
     };
     const result = await exa.agent.runs.create(params);


### PR DESCRIPTION
## Summary

Adds `minimal` to the Agent API `effort` type so TypeScript SDK callers can use the new effort option.

## Validation

- `npm run test:unit -- test/unit/agent.test.ts`
- `npm run build`

Note: `npm run typecheck` currently fails on unrelated existing examples/websets/test typing errors from `origin/master`.