### PR TITLE
feat(agent): add Exa Connect dataSources support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,14 @@ const run = await exa.agent.runs.create({
     required: ["people"],
   },
   effort: "auto",
+  // Optionally enable Exa Connect data providers for the run.
+  dataSources: [{ provider: "financial_datasets" }],
 });
 
 const completedRun = await exa.agent.runs.pollUntilFinished(run.id);
 console.log(completedRun.output?.structured);
+// Per-provider tool-call counts and cost for any Exa Connect data sources used.
+console.log(completedRun.usage?.dataSources, completedRun.costDollars?.dataSources);
 ```
 
 ## TypeScript

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -15,6 +15,8 @@ export type {
   AgentBetaOptions,
   AgentCreateOptions,
   AgentConfidence,
+  AgentDataSource,
+  AgentDataSourceProvider,
   AgentEffort,
   AgentError,
   AgentEvent,

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -35,16 +35,12 @@ export type AgentConfidence = "low" | "medium" | "high";
 
 export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "auto";
 
-/** Identifier of an Exa Connect data provider. */
-export type AgentDataSourceProvider =
-  | "fiber_ai"
-  | "financial_datasets"
-  | "similar_web"
-  | "baselayer"
-  | "affiliate"
-  | "particle_news"
-  | "jinko"
-  | (string & {});
+/**
+ * Identifier of an Exa Connect data provider, e.g. `"fiber_ai"`,
+ * `"financial_datasets"`, `"similar_web"`, `"baselayer"`, `"affiliate"`,
+ * `"particle_news"`, or `"jinko"`.
+ */
+export type AgentDataSourceProvider = string;
 
 /** Exa Connect data source to enable for an Agent run. */
 export interface AgentDataSource {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -43,7 +43,8 @@ export type AgentDataSourceProvider =
   | "baselayer"
   | "affiliate"
   | "particle_news"
-  | "jinko";
+  | "jinko"
+  | (string & {});
 
 /** Exa Connect data source to enable for an Agent run. */
 export interface AgentDataSource {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -35,6 +35,22 @@ export type AgentConfidence = "low" | "medium" | "high";
 
 export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "auto";
 
+/** Identifier of an Exa Connect data provider. */
+export type AgentDataSourceProvider =
+  | "fiber_ai"
+  | "financial_datasets"
+  | "similar_web"
+  | "baselayer"
+  | "affiliate"
+  | "particle_news"
+  | "jinko";
+
+/** Exa Connect data source to enable for an Agent run. */
+export interface AgentDataSource {
+  /** Exa Connect data provider to enable for the run. */
+  provider: AgentDataSourceProvider;
+}
+
 export interface AgentInput {
   data?: Record<string, unknown>[];
   exclusion?: Record<string, unknown>[];
@@ -67,6 +83,8 @@ export interface AgentUsage {
   searches?: number;
   emails?: number;
   phoneNumbers?: number;
+  /** Per-provider tool call counts for Exa Connect data sources used during the run. */
+  dataSources?: Record<string, number>;
   [key: string]: unknown;
 }
 
@@ -76,6 +94,8 @@ export interface AgentCostDollars {
   search?: number;
   emails?: number;
   phoneNumbers?: number;
+  /** Per-provider cost in dollars for Exa Connect data sources used during the run. */
+  dataSources?: Record<string, number>;
   [key: string]: unknown;
 }
 
@@ -155,6 +175,8 @@ export interface CreateAgentRunParams {
   effort?: AgentEffort;
   previousRunId?: string;
   metadata?: Record<string, unknown>;
+  /** Exa Connect data providers to enable for the run. Each entry enables all of that provider's tools. */
+  dataSources?: AgentDataSource[];
 }
 
 export type CreateAgentRunParamsTyped<T> = Omit<

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -121,6 +121,36 @@ describe("Agent API", () => {
     expect(result).toEqual(mockResponse);
   });
 
+  it("passes Exa Connect data sources through and round-trips per-provider usage", async () => {
+    // Typing this literal as AgentRun proves AgentUsage/AgentCostDollars accept
+    // the new per-provider `dataSources` maps at compile time.
+    const mockResponse: AgentRun = {
+      ...createMockRun(),
+      usage: { agentComputeUnits: 0.1, dataSources: { financial_datasets: 3 } },
+      costDollars: { total: 0.05, dataSources: { financial_datasets: 0.04 } },
+    };
+    const runClient = getProtectedClient(exa.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(mockResponse);
+
+    const result = await exa.agent.runs.create({
+      query: "Find recent financials for Acme.",
+      dataSources: [
+        { provider: "financial_datasets" },
+        // Arbitrary provider strings are accepted by the widened union.
+        { provider: "custom_provider" },
+      ],
+    });
+
+    const payload = requestSpy.mock.calls[0][2] as Record<string, any>;
+    expect(payload.dataSources).toEqual([
+      { provider: "financial_datasets" },
+      { provider: "custom_provider" },
+    ]);
+    expect(result).toEqual(mockResponse);
+  });
+
   it("sends legacy beta values as headers when creating an Agent run from the beta namespace", async () => {
     const runClient = getProtectedClient(exa.beta.agent.runs);
     const requestSpy = vi

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -138,7 +138,7 @@ describe("Agent API", () => {
       query: "Find recent financials for Acme.",
       dataSources: [
         { provider: "financial_datasets" },
-        // Arbitrary provider strings are accepted by the widened union.
+        // provider is a plain string, so any provider slug is accepted.
         { provider: "custom_provider" },
       ],
     });


### PR DESCRIPTION
Adds Exa Connect `dataSources` support to the Agent API: new `AgentDataSource` and `AgentDataSourceProvider` types (the provider is a plain `string`, with the known provider slugs documented as JSDoc examples), a `dataSources` parameter on `CreateAgentRunParams`, and per-provider `dataSources` maps on `AgentUsage` and `AgentCostDollars` — all exported from the top-level package. The parameter flows through the existing payload spread to the create request as camelCase, consistent with the rest of the agent surface, so both `exa.agent.runs.create` and the legacy `exa.beta.agent.runs.create` accept it. This PR also adds unit coverage verifying `dataSources` is forwarded to the request payload (with a known slug and an arbitrary string) and round-trips the new usage/cost maps, and documents the field in the README Agent example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)