### PR TITLE
fix(agent): preserve typed Agent run fields with outputSchema

### DIFF
--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -122,8 +122,8 @@ export interface AgentRun {
   [key: string]: unknown;
 }
 
-export type AgentRunTyped<T> = Omit<AgentRun, "output"> & {
-  output?: (Omit<AgentOutput, "structured"> & { structured?: T }) | null;
+export type AgentRunTyped<T> = AgentRun & {
+  output?: (AgentOutput & { structured?: T }) | null;
 };
 
 export interface ListAgentRunsParams {

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest";
 import { z } from "zod";
 import Exa from "../../src";
 import {
@@ -210,6 +218,32 @@ describe("Agent API", () => {
     expect(payload.outputSchema.type).toBe("object");
     expect(payload.outputSchema.properties.companyName.type).toBe("string");
     expect(payload.betas).toBeUndefined();
+  });
+
+  it("preserves typed run fields when outputSchema is provided", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    vi.spyOn(runClient, "request").mockResolvedValueOnce(createMockRun());
+    vi.spyOn(exa.agent.runs, "get").mockResolvedValueOnce(createMockRun());
+
+    const run = await exa.agent.runs.create({
+      query: "Find recent funding rounds.",
+      outputSchema: z.object({
+        companies: z.array(
+          z.object({
+            name: z.string(),
+          })
+        ),
+      }),
+    });
+
+    expectTypeOf(run.id).toEqualTypeOf<string>();
+    expectTypeOf(run.status).toEqualTypeOf<AgentRun["status"]>();
+    expectTypeOf(run.output?.structured).toEqualTypeOf<
+      { companies: { name: string }[] } | undefined
+    >();
+
+    const completedRun = await exa.agent.runs.pollUntilFinished(run.id);
+    expect(completedRun.id).toBe("agent_run_123");
   });
 
   it("accepts contact fields in output schemas", async () => {


### PR DESCRIPTION
## Summary

Fixes the typed Agent run returned from `exa.agent.runs.create({ outputSchema: ... })` so fields like `id` keep their expected types instead of being inferred as `unknown`.

That means this works as expected:

`const completedRun = await exa.agent.runs.pollUntilFinished(run.id);`

instead of callers needing workarounds like:

`const completedRun = await exa.agent.runs.pollUntilFinished(String(run.id));
`