### PR TITLE
feat(agent): add createAndWait helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,37 +123,44 @@ for await (const chunk of exa.streamAnswer("Explain quantum computing")) {
 ## Agent API
 
 ```ts
-const run = await exa.agent.runs.create({
-  query:
-    "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
-  outputSchema: {
-    type: "object",
-    properties: {
-      people: {
-        type: "array",
-        maxItems: 10,
-        items: {
-          type: "object",
-          properties: {
-            name: { type: "string" },
-            contact_email: { type: "string", format: "email" },
-            linkedin_url: { type: "string", format: "uri" },
+const completedRun = await exa.agent.runs.createAndWait(
+  {
+    query:
+      "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
+    outputSchema: {
+      type: "object",
+      properties: {
+        people: {
+          type: "array",
+          maxItems: 10,
+          items: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              contact_email: { type: "string", format: "email" },
+              linkedin_url: { type: "string", format: "uri" },
+            },
+            required: ["name", "linkedin_url"],
           },
-          required: ["name", "linkedin_url"],
         },
       },
+      required: ["people"],
     },
-    required: ["people"],
+    effort: "auto",
+    // Optionally enable Exa Connect data providers for the run.
+    dataSources: [{ provider: "financial_datasets" }],
   },
-  effort: "auto",
-  // Optionally enable Exa Connect data providers for the run.
-  dataSources: [{ provider: "financial_datasets" }],
-});
+  {
+    timeoutMs: 600_000,
+  }
+);
 
-const completedRun = await exa.agent.runs.pollUntilFinished(run.id);
 console.log(completedRun.output?.structured);
 // Per-provider tool-call counts and cost for any Exa Connect data sources used.
-console.log(completedRun.usage?.dataSources, completedRun.costDollars?.dataSources);
+console.log(
+  completedRun.usage?.dataSources,
+  completedRun.costDollars?.dataSources
+);
 ```
 
 ## TypeScript

--- a/README.md
+++ b/README.md
@@ -123,44 +123,37 @@ for await (const chunk of exa.streamAnswer("Explain quantum computing")) {
 ## Agent API
 
 ```ts
-const completedRun = await exa.agent.runs.createAndWait(
-  {
-    query:
-      "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
-    outputSchema: {
-      type: "object",
-      properties: {
-        people: {
-          type: "array",
-          maxItems: 10,
-          items: {
-            type: "object",
-            properties: {
-              name: { type: "string" },
-              contact_email: { type: "string", format: "email" },
-              linkedin_url: { type: "string", format: "uri" },
-            },
-            required: ["name", "linkedin_url"],
+const run = await exa.agent.runs.create({
+  query:
+    "Find engineering leaders at AI infrastructure companies that raised a Series A or B in the last 6 months.",
+  outputSchema: {
+    type: "object",
+    properties: {
+      people: {
+        type: "array",
+        maxItems: 10,
+        items: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            contact_email: { type: "string", format: "email" },
+            linkedin_url: { type: "string", format: "uri" },
           },
+          required: ["name", "linkedin_url"],
         },
       },
-      required: ["people"],
     },
-    effort: "auto",
-    // Optionally enable Exa Connect data providers for the run.
-    dataSources: [{ provider: "financial_datasets" }],
+    required: ["people"],
   },
-  {
-    timeoutMs: 600_000,
-  }
-);
+  effort: "auto",
+  // Optionally enable Exa Connect data providers for the run.
+  dataSources: [{ provider: "financial_datasets" }],
+});
 
+const completedRun = await exa.agent.runs.pollUntilFinished(run.id);
 console.log(completedRun.output?.structured);
 // Per-provider tool-call counts and cost for any Exa Connect data sources used.
-console.log(
-  completedRun.usage?.dataSources,
-  completedRun.costDollars?.dataSources
-);
+console.log(completedRun.usage?.dataSources, completedRun.costDollars?.dataSources);
 ```
 
 ## TypeScript

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -31,6 +31,11 @@ type AgentCompletedRun = AgentRun & { status: "completed" };
 type AgentCompletedRunTyped<T> = AgentRunTyped<T> & {
   status: "completed";
 };
+const TERMINAL_AGENT_RUN_STATUSES = new Set<AgentTerminalStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+]);
 export type AgentWaitOptions = {
   pollInterval?: number;
   timeoutMs?: number;
@@ -62,12 +67,10 @@ function headersForBetas(betas?: string[]): Record<string, string> | undefined {
   return { "Exa-Beta": betaValues.join(",") };
 }
 
-function agentCreateParamsWithoutStream<T>(
-  params: Omit<AgentCreateOptions<T>, "stream">
-): Omit<AgentCreateOptions<T>, "stream"> {
-  const copy = { ...params };
-  delete (copy as { stream?: unknown }).stream;
-  return copy;
+function isTerminalAgentRunStatus(
+  status: AgentRun["status"]
+): status is AgentTerminalStatus {
+  return TERMINAL_AGENT_RUN_STATUSES.has(status as AgentTerminalStatus);
 }
 
 function ensureCompletedRun<T>(
@@ -306,11 +309,7 @@ export class AgentRunsClient extends AgentBaseClient {
 
     while (true) {
       const run = await this.get(runId);
-      if (
-        run.status === "completed" ||
-        run.status === "failed" ||
-        run.status === "cancelled"
-      ) {
+      if (isTerminalAgentRunStatus(run.status)) {
         return run as AgentTerminalRun;
       }
 
@@ -339,17 +338,12 @@ export class AgentRunsClient extends AgentBaseClient {
     params: Omit<AgentCreateOptions<T>, "stream">,
     options?: AgentWaitOptions
   ): Promise<AgentCompletedRunTyped<T>> {
-    const createParams = agentCreateParamsWithoutStream(params);
+    const { stream: _stream, ...createParams } =
+      params as AgentCreateOptions<T>;
     const run = (await this.create(
-      createParams as AgentCreateOptions<T> & {
-        stream?: false;
-      }
+      createParams as AgentCreateOptions<T> & { stream?: false }
     )) as AgentRunTyped<T>;
-    if (
-      run.status === "completed" ||
-      run.status === "failed" ||
-      run.status === "cancelled"
-    ) {
+    if (isTerminalAgentRunStatus((run as AgentRun).status)) {
       return ensureCompletedRun(run as AgentTerminalRunTyped<T>);
     }
     const runId = (run as AgentRun).id;
@@ -552,11 +546,7 @@ export class AgentBetaRunsClient extends AgentRunsClient {
         undefined,
         headers
       );
-      if (
-        run.status === "completed" ||
-        run.status === "failed" ||
-        run.status === "cancelled"
-      ) {
+      if (isTerminalAgentRunStatus(run.status)) {
         return run as AgentTerminalRun;
       }
 
@@ -582,19 +572,16 @@ export class AgentBetaRunsClient extends AgentRunsClient {
     params: WithBetaOptions<Omit<AgentCreateOptions<T>, "stream">>,
     options?: AgentWaitOptions
   ): Promise<AgentCompletedRunTyped<T>> {
-    const { betas, ...createParams } = params;
-    const safeCreateParams = agentCreateParamsWithoutStream(
-      createParams as Omit<AgentCreateOptions<T>, "stream">
-    );
+    const {
+      betas,
+      stream: _stream,
+      ...createParams
+    } = params as WithBetaOptions<AgentCreateOptions<T>>;
     const run = (await this.create({
-      ...safeCreateParams,
+      ...createParams,
       betas,
     })) as AgentRunTyped<T>;
-    if (
-      run.status === "completed" ||
-      run.status === "failed" ||
-      run.status === "cancelled"
-    ) {
+    if (isTerminalAgentRunStatus((run as AgentRun).status)) {
       return ensureCompletedRun(run as AgentTerminalRunTyped<T>);
     }
     const runId = (run as AgentRun).id;

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -31,6 +31,9 @@ type AgentCompletedRun = AgentRun & { status: "completed" };
 type AgentCompletedRunTyped<T> = AgentRunTyped<T> & {
   status: "completed";
 };
+const DEFAULT_AGENT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_AGENT_POLL_TIMEOUT_MS = 60 * 60 * 1000;
+const DEFAULT_AGENT_CREATE_AND_WAIT_TIMEOUT_MS = 2 * 60 * 1000;
 const TERMINAL_AGENT_RUN_STATUSES = new Set<AgentTerminalStatus>([
   "completed",
   "failed",
@@ -83,6 +86,15 @@ function ensureCompletedRun<T>(
     throw new AgentRunCancelledError(run as AgentRun & { status: "cancelled" });
   }
   return run as AgentCompletedRunTyped<T>;
+}
+
+function createAndWaitPollOptions(
+  options?: AgentWaitOptions
+): AgentWaitOptions {
+  return {
+    pollInterval: options?.pollInterval ?? DEFAULT_AGENT_POLL_INTERVAL_MS,
+    timeoutMs: options?.timeoutMs ?? DEFAULT_AGENT_CREATE_AND_WAIT_TIMEOUT_MS,
+  };
 }
 
 function buildAgentRunPayload<T>(params: AgentCreateOptions<T>): {
@@ -303,8 +315,9 @@ export class AgentRunsClient extends AgentBaseClient {
     runId: string,
     options?: AgentWaitOptions
   ): Promise<AgentTerminalRun> {
-    const pollInterval = options?.pollInterval ?? 1000;
-    const timeoutMs = options?.timeoutMs ?? 60 * 60 * 1000;
+    const pollInterval =
+      options?.pollInterval ?? DEFAULT_AGENT_POLL_INTERVAL_MS;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_AGENT_POLL_TIMEOUT_MS;
     const startTime = Date.now();
 
     while (true) {
@@ -349,7 +362,7 @@ export class AgentRunsClient extends AgentBaseClient {
     const runId = (run as AgentRun).id;
     const terminalRun = (await this.pollUntilFinished(
       runId,
-      options
+      createAndWaitPollOptions(options)
     )) as AgentTerminalRunTyped<T>;
     return ensureCompletedRun(terminalRun);
   }
@@ -533,8 +546,9 @@ export class AgentBetaRunsClient extends AgentRunsClient {
     runId: string,
     options?: WithBetaOptions<AgentWaitOptions>
   ): Promise<AgentTerminalRun> {
-    const pollInterval = options?.pollInterval ?? 1000;
-    const timeoutMs = options?.timeoutMs ?? 60 * 60 * 1000;
+    const pollInterval =
+      options?.pollInterval ?? DEFAULT_AGENT_POLL_INTERVAL_MS;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_AGENT_POLL_TIMEOUT_MS;
     const startTime = Date.now();
     const headers = headersForBetas(options?.betas);
 
@@ -586,7 +600,7 @@ export class AgentBetaRunsClient extends AgentRunsClient {
     }
     const runId = (run as AgentRun).id;
     const terminalRun = (await this.pollUntilFinished(runId, {
-      ...options,
+      ...createAndWaitPollOptions(options),
       betas,
     })) as AgentTerminalRunTyped<T>;
     return ensureCompletedRun(terminalRun);

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -356,9 +356,6 @@ export class AgentRunsClient extends AgentBaseClient {
     const run = (await this.create(
       createParams as AgentCreateOptions<T> & { stream?: false }
     )) as AgentRunTyped<T>;
-    if (isTerminalAgentRunStatus((run as AgentRun).status)) {
-      return ensureCompletedRun(run as AgentTerminalRunTyped<T>);
-    }
     const runId = (run as AgentRun).id;
     const terminalRun = (await this.pollUntilFinished(
       runId,
@@ -595,9 +592,6 @@ export class AgentBetaRunsClient extends AgentRunsClient {
       ...createParams,
       betas,
     })) as AgentRunTyped<T>;
-    if (isTerminalAgentRunStatus((run as AgentRun).status)) {
-      return ensureCompletedRun(run as AgentTerminalRunTyped<T>);
-    }
     const runId = (run as AgentRun).id;
     const terminalRun = (await this.pollUntilFinished(runId, {
       ...createAndWaitPollOptions(options),

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -22,11 +22,64 @@ import {
 } from "./types";
 
 type WithBetaOptions<T> = T & AgentBetaOptions;
+type AgentTerminalStatus = "completed" | "failed" | "cancelled";
+type AgentTerminalRun = AgentRun & { status: AgentTerminalStatus };
+type AgentTerminalRunTyped<T> = AgentRunTyped<T> & {
+  status: AgentTerminalStatus;
+};
+type AgentCompletedRun = AgentRun & { status: "completed" };
+type AgentCompletedRunTyped<T> = AgentRunTyped<T> & {
+  status: "completed";
+};
+export type AgentWaitOptions = {
+  pollInterval?: number;
+  timeoutMs?: number;
+};
+
+export class AgentRunFailedError extends Error {
+  run: AgentRun & { status: "failed" };
+
+  constructor(run: AgentRun & { status: "failed" }) {
+    super(run.error?.message ?? `Agent run ${run.id} failed`);
+    this.name = "AgentRunFailedError";
+    this.run = run;
+  }
+}
+
+export class AgentRunCancelledError extends Error {
+  run: AgentRun & { status: "cancelled" };
+
+  constructor(run: AgentRun & { status: "cancelled" }) {
+    super(`Agent run ${run.id} was cancelled`);
+    this.name = "AgentRunCancelledError";
+    this.run = run;
+  }
+}
 
 function headersForBetas(betas?: string[]): Record<string, string> | undefined {
   const betaValues = betas?.filter(Boolean);
   if (!betaValues?.length) return undefined;
   return { "Exa-Beta": betaValues.join(",") };
+}
+
+function agentCreateParamsWithoutStream<T>(
+  params: Omit<AgentCreateOptions<T>, "stream">
+): Omit<AgentCreateOptions<T>, "stream"> {
+  const copy = { ...params };
+  delete (copy as { stream?: unknown }).stream;
+  return copy;
+}
+
+function ensureCompletedRun<T>(
+  run: AgentTerminalRunTyped<T>
+): AgentCompletedRunTyped<T> {
+  if (run.status === "failed") {
+    throw new AgentRunFailedError(run as AgentRun & { status: "failed" });
+  }
+  if (run.status === "cancelled") {
+    throw new AgentRunCancelledError(run as AgentRun & { status: "cancelled" });
+  }
+  return run as AgentCompletedRunTyped<T>;
 }
 
 function buildAgentRunPayload<T>(params: AgentCreateOptions<T>): {
@@ -245,11 +298,8 @@ export class AgentRunsClient extends AgentBaseClient {
    */
   async pollUntilFinished(
     runId: string,
-    options?: {
-      pollInterval?: number;
-      timeoutMs?: number;
-    }
-  ): Promise<AgentRun & { status: "completed" | "failed" | "cancelled" }> {
+    options?: AgentWaitOptions
+  ): Promise<AgentTerminalRun> {
     const pollInterval = options?.pollInterval ?? 1000;
     const timeoutMs = options?.timeoutMs ?? 60 * 60 * 1000;
     const startTime = Date.now();
@@ -261,9 +311,7 @@ export class AgentRunsClient extends AgentBaseClient {
         run.status === "failed" ||
         run.status === "cancelled"
       ) {
-        return run as AgentRun & {
-          status: "completed" | "failed" | "cancelled";
-        };
+        return run as AgentTerminalRun;
       }
 
       if (Date.now() - startTime > timeoutMs) {
@@ -274,6 +322,42 @@ export class AgentRunsClient extends AgentBaseClient {
 
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
+  }
+
+  /**
+   * Create an Agent run and wait until it reaches a terminal status.
+   */
+  async createAndWait<T>(
+    params: Omit<AgentCreateOptions<T>, "stream">,
+    options?: AgentWaitOptions
+  ): Promise<AgentCompletedRunTyped<T>>;
+  async createAndWait(
+    params: CreateAgentRunParams,
+    options?: AgentWaitOptions
+  ): Promise<AgentCompletedRun>;
+  async createAndWait<T>(
+    params: Omit<AgentCreateOptions<T>, "stream">,
+    options?: AgentWaitOptions
+  ): Promise<AgentCompletedRunTyped<T>> {
+    const createParams = agentCreateParamsWithoutStream(params);
+    const run = (await this.create(
+      createParams as AgentCreateOptions<T> & {
+        stream?: false;
+      }
+    )) as AgentRunTyped<T>;
+    if (
+      run.status === "completed" ||
+      run.status === "failed" ||
+      run.status === "cancelled"
+    ) {
+      return ensureCompletedRun(run as AgentTerminalRunTyped<T>);
+    }
+    const runId = (run as AgentRun).id;
+    const terminalRun = (await this.pollUntilFinished(
+      runId,
+      options
+    )) as AgentTerminalRunTyped<T>;
+    return ensureCompletedRun(terminalRun);
   }
 }
 
@@ -453,11 +537,8 @@ export class AgentBetaRunsClient extends AgentRunsClient {
 
   async pollUntilFinished(
     runId: string,
-    options?: WithBetaOptions<{
-      pollInterval?: number;
-      timeoutMs?: number;
-    }>
-  ): Promise<AgentRun & { status: "completed" | "failed" | "cancelled" }> {
+    options?: WithBetaOptions<AgentWaitOptions>
+  ): Promise<AgentTerminalRun> {
     const pollInterval = options?.pollInterval ?? 1000;
     const timeoutMs = options?.timeoutMs ?? 60 * 60 * 1000;
     const startTime = Date.now();
@@ -476,9 +557,7 @@ export class AgentBetaRunsClient extends AgentRunsClient {
         run.status === "failed" ||
         run.status === "cancelled"
       ) {
-        return run as AgentRun & {
-          status: "completed" | "failed" | "cancelled";
-        };
+        return run as AgentTerminalRun;
       }
 
       if (Date.now() - startTime > timeoutMs) {
@@ -489,6 +568,41 @@ export class AgentBetaRunsClient extends AgentRunsClient {
 
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
+  }
+
+  async createAndWait<T>(
+    params: WithBetaOptions<Omit<AgentCreateOptions<T>, "stream">>,
+    options?: AgentWaitOptions
+  ): Promise<AgentCompletedRunTyped<T>>;
+  async createAndWait(
+    params: CreateAgentRunParams & AgentBetaOptions,
+    options?: AgentWaitOptions
+  ): Promise<AgentCompletedRun>;
+  async createAndWait<T>(
+    params: WithBetaOptions<Omit<AgentCreateOptions<T>, "stream">>,
+    options?: AgentWaitOptions
+  ): Promise<AgentCompletedRunTyped<T>> {
+    const { betas, ...createParams } = params;
+    const safeCreateParams = agentCreateParamsWithoutStream(
+      createParams as Omit<AgentCreateOptions<T>, "stream">
+    );
+    const run = (await this.create({
+      ...safeCreateParams,
+      betas,
+    })) as AgentRunTyped<T>;
+    if (
+      run.status === "completed" ||
+      run.status === "failed" ||
+      run.status === "cancelled"
+    ) {
+      return ensureCompletedRun(run as AgentTerminalRunTyped<T>);
+    }
+    const runId = (run as AgentRun).id;
+    const terminalRun = (await this.pollUntilFinished(runId, {
+      ...options,
+      betas,
+    })) as AgentTerminalRunTyped<T>;
+    return ensureCompletedRun(terminalRun);
   }
 }
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -6,9 +6,13 @@ export {
   AgentClient,
   AgentBetaClient,
   AgentRunsClient,
+  AgentRunCancelledError,
+  AgentRunFailedError,
   AgentRunEventsClient,
   BetaClient,
 } from "./client";
+
+export type { AgentWaitOptions } from "./client";
 
 export type {
   AgentCostDollars,

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -794,7 +794,11 @@ describe("Agent API", () => {
     const runClient = getProtectedClient(exa.agent.runs);
     const requestSpy = vi
       .spyOn(runClient, "request")
-      .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
+      .mockResolvedValueOnce({ ...createMockRun(), status: "running" });
+    vi.spyOn(exa.agent.runs, "pollUntilFinished").mockResolvedValueOnce({
+      ...createMockRun(),
+      status: "completed",
+    });
 
     const result = await exa.agent.runs.createAndWait({
       query: "Find companies.",

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -729,6 +729,24 @@ describe("Agent API", () => {
     expect(requestSpy).toHaveBeenNthCalledWith(2, "/agent_run_123", "GET");
   });
 
+  it("uses two minute timeout defaults for createAndWait polling", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    vi.spyOn(runClient, "request").mockResolvedValueOnce({
+      ...createMockRun(),
+      status: "running",
+    });
+    const pollSpy = vi
+      .spyOn(exa.agent.runs, "pollUntilFinished")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
+
+    await exa.agent.runs.createAndWait({ query: "Find companies." });
+
+    expect(pollSpy).toHaveBeenCalledWith("agent_run_123", {
+      pollInterval: 1000,
+      timeoutMs: 120000,
+    });
+  });
+
   it("throws by default when createAndWait reaches a failed run", async () => {
     const runClient = getProtectedClient(exa.agent.runs);
     const failedRun: AgentRun = {

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -6,6 +6,8 @@ import {
   AgentClient,
   AGENT_BETA_HEADER,
   BetaClient,
+  AgentRunCancelledError,
+  AgentRunFailedError,
 } from "../../src/agent";
 import {
   AgentRun,
@@ -91,6 +93,15 @@ describe("Agent API", () => {
       // @ts-expect-error betas are only accepted through exa.beta.agent.
       exa.agent.runs.get("agent_run_123", { betas: [] });
       exa.beta.agent.runs.get("agent_run_123", {
+        betas: [AGENT_BETA_HEADER],
+      });
+      exa.agent.runs.createAndWait({
+        query: "Find companies.",
+        // @ts-expect-error betas are only accepted through exa.beta.agent.
+        betas: [],
+      });
+      exa.beta.agent.runs.createAndWait({
+        query: "Find companies.",
         betas: [AGENT_BETA_HEADER],
       });
       new AgentBetaClient(exa).runs.create({
@@ -695,6 +706,89 @@ describe("Agent API", () => {
     expect(getSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("creates an Agent run and waits until it reaches a terminal status", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "running" })
+      .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
+
+    const result = await exa.agent.runs.createAndWait(
+      {
+        query: "Find companies.",
+        outputSchema: { type: "object" },
+      },
+      { pollInterval: 5, timeoutMs: 1000 }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(requestSpy).toHaveBeenNthCalledWith(1, "", "POST", {
+      query: "Find companies.",
+      outputSchema: { type: "object" },
+    });
+    expect(requestSpy).toHaveBeenNthCalledWith(2, "/agent_run_123", "GET");
+  });
+
+  it("throws by default when createAndWait reaches a failed run", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    const failedRun: AgentRun = {
+      ...createMockRun(),
+      status: "failed",
+      error: { message: "Could not produce a final answer." },
+    };
+    vi.spyOn(runClient, "request")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "running" })
+      .mockResolvedValueOnce(failedRun);
+
+    const promise = exa.agent.runs.createAndWait(
+      { query: "Find companies." },
+      { pollInterval: 5, timeoutMs: 1000 }
+    );
+
+    await expect(promise).rejects.toBeInstanceOf(AgentRunFailedError);
+    await expect(promise).rejects.toMatchObject({
+      name: "AgentRunFailedError",
+      message: "Could not produce a final answer.",
+      run: failedRun,
+    });
+  });
+
+  it("throws by default when createAndWait reaches a cancelled run", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    const cancelledRun: AgentRun = {
+      ...createMockRun(),
+      status: "cancelled",
+      stopReason: "cancelled",
+    };
+    vi.spyOn(runClient, "request")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "running" })
+      .mockResolvedValueOnce(cancelledRun);
+
+    await expect(
+      exa.agent.runs.createAndWait(
+        { query: "Find companies." },
+        { pollInterval: 5, timeoutMs: 1000 }
+      )
+    ).rejects.toBeInstanceOf(AgentRunCancelledError);
+  });
+
+  it("ignores a runtime stream flag in createAndWait", async () => {
+    const runClient = getProtectedClient(exa.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
+
+    const result = await exa.agent.runs.createAndWait({
+      query: "Find companies.",
+      stream: true,
+    } as any);
+
+    expect(result.status).toBe("completed");
+    expect(requestSpy).toHaveBeenCalledWith("", "POST", {
+      query: "Find companies.",
+    });
+  });
+
   it("polls with legacy beta headers from the beta namespace", async () => {
     vi.useFakeTimers();
     const runClient = getProtectedClient(exa.beta.agent.runs);
@@ -723,6 +817,40 @@ describe("Agent API", () => {
       "/agent_run_123",
       "GET",
       undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      2,
+      "/agent_run_123",
+      "GET",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+  });
+
+  it("creates and waits with legacy beta headers from the beta namespace", async () => {
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce({ ...createMockRun(), status: "running" })
+      .mockResolvedValueOnce({ ...createMockRun(), status: "completed" });
+
+    const result = await exa.beta.agent.runs.createAndWait(
+      {
+        betas: [AGENT_BETA_HEADER],
+        query: "Find companies.",
+      },
+      { pollInterval: 5, timeoutMs: 1000 }
+    );
+
+    expect(result.status).toBe("completed");
+    expect(requestSpy).toHaveBeenNthCalledWith(
+      1,
+      "",
+      "POST",
+      { query: "Find companies." },
       undefined,
       { "Exa-Beta": AGENT_BETA_HEADER }
     );


### PR DESCRIPTION
## Summary

Adds `exa.agent.runs.createAndWait(...)` for the Agent API. The helper creates an Agent run, polls until the run reaches a terminal state, and returns only completed runs. If the terminal run is `failed` or `cancelled`, it rejects with `AgentRunFailedError` or `AgentRunCancelledError`; both errors carry the terminal run on `.run` for debugging.

The lower-level existing APIs remain unchanged: `create`, streaming create, and `pollUntilFinished` still expose their existing behavior. `pollUntilFinished` continues to return any terminal run normally for callers that want to inspect `run.status` themselves.

This also preserves the deprecated beta namespace behavior, including beta headers during both create and poll, and strips a runtime `stream: true` value from `createAndWait` so the convenience helper cannot accidentally receive an SSE generator instead of a run.

## Validation

- `npm run test:unit -- test/unit/agent.test.ts`
- `npm run build-fast`
- `npx prettier --check src/agent/client.ts src/agent/index.ts test/unit/agent.test.ts README.md`
- `git diff --check`
