### PR TITLE
fix: pin publish workflow to npm@11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,8 +39,10 @@ jobs:
           registry-url: https://registry.npmjs.org/
           scope: '@exa-labs'
 
+      # Pin to npm@11 (needs >=11.5.1 for trusted publishing). npm@latest is
+      # npm 12 and requires Node 22+, which breaks this Node 20 job.
       - name: Ensure npm 11.5.1+
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Pin the publish workflow to `npm@11` so trusted publishing still works on Node 20; `npm@latest` now resolves to npm 12 which requires Node 22+.

## Test plan
- [ ] Merge and re-run publish for `v2.16.2`
- [ ] Confirm `exa-js@2.16.2` appears on npm