### PR TITLE
fix: ExaError.message is [object Object] for agent-shaped error envelopes

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,6 +13,27 @@ export enum HttpStatusCode {
 }
 
 /**
+ * Structured details from APIs that return a nested error envelope
+ * ({ error: { type, code, message } }), e.g. the agent surface.
+ */
+export interface ExaErrorDetails {
+  /**
+   * Error category from the API, e.g. "INVALID_REQUEST" or "CONFLICT"
+   */
+  type?: string;
+
+  /**
+   * Specific error code from the API, e.g. "MONITOR_NOT_FOUND"
+   */
+  code?: string;
+
+  /**
+   * Request ID from the API, when provided
+   */
+  requestId?: string;
+}
+
+/**
  * Base error class for all Exa API errors
  */
 export class ExaError extends Error {
@@ -32,22 +53,42 @@ export class ExaError extends Error {
   path?: string;
 
   /**
+   * Error category from the API (nested error envelopes only)
+   */
+  type?: string;
+
+  /**
+   * Specific error code from the API (nested error envelopes only)
+   */
+  code?: string;
+
+  /**
+   * Request ID from the API, when provided
+   */
+  requestId?: string;
+
+  /**
    * Create a new ExaError
    * @param message Error message
    * @param statusCode HTTP status code
    * @param timestamp ISO timestamp from API
    * @param path Path that caused the error
+   * @param details Structured details from nested error envelopes
    */
   constructor(
     message: string,
     statusCode: number,
     timestamp?: string,
-    path?: string
+    path?: string,
+    details?: ExaErrorDetails
   ) {
     super(message);
     this.name = "ExaError";
     this.statusCode = statusCode;
     this.timestamp = timestamp ?? new Date().toISOString();
     this.path = path;
+    this.type = details?.type;
+    this.code = details?.code;
+    this.requestId = details?.requestId;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -954,8 +954,27 @@ export class Exa {
         errorData.path = endpoint;
       }
 
-      // For other APIs, throw a simple ExaError with just message and status
-      let message = errorData.error || "Unknown error";
+      // Two error envelopes exist: the legacy string form
+      // ({ error: "Bad Request", message: "..." }) and the agent surface's
+      // nested object ({ error: { type, code, message } }). Concatenating the
+      // object form would render the message as "[object Object]", so unwrap
+      // it and preserve its structured fields on the thrown error.
+      const errorValue: unknown = errorData.error;
+      let message: string;
+      let type: string | undefined;
+      let code: string | undefined;
+      if (errorValue !== null && typeof errorValue === "object") {
+        const nested = errorValue as Record<string, unknown>;
+        type = typeof nested.type === "string" ? nested.type : undefined;
+        code = typeof nested.code === "string" ? nested.code : undefined;
+        message =
+          typeof nested.message === "string" && nested.message
+            ? nested.message
+            : (code ?? type ?? "Unknown error");
+      } else {
+        message =
+          (typeof errorValue === "string" && errorValue) || "Unknown error";
+      }
       if (errorData.message) {
         message += (message.length > 0 ? ". " : "") + errorData.message;
       }
@@ -963,7 +982,15 @@ export class Exa {
         message,
         response.status,
         errorData.timestamp,
-        errorData.path
+        errorData.path,
+        {
+          type,
+          code,
+          requestId:
+            typeof errorData.requestId === "string"
+              ? errorData.requestId
+              : undefined,
+        }
       );
     }
 

--- a/test/unit/request-error-handling.test.ts
+++ b/test/unit/request-error-handling.test.ts
@@ -35,6 +35,27 @@ function handle(url: string): {
           message: "Invalid query",
         }),
       };
+    case "/agent-error":
+      return {
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            type: "CONFLICT",
+            code: "IDEMPOTENCY_KEY_CONFLICT",
+            message: "Idempotency-Key was already used for a different request",
+          },
+          requestId: "req_e2e123",
+        }),
+      };
+    case "/agent-error-no-message":
+      return {
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { type: "NOT_FOUND", code: "MONITOR_NOT_FOUND" },
+        }),
+      };
     case "/empty-ok":
       return { status: 200, contentType: "application/json", body: "" };
     default:
@@ -88,11 +109,43 @@ describe("Exa.request non-JSON response handling", () => {
   });
 
   it("still surfaces structured JSON API errors unchanged", async () => {
-    const error = await exa.request("/json-error", "POST").catch((e) => e);
+    const error = (await exa
+      .request("/json-error", "POST")
+      .catch((e) => e)) as ExaError;
     expect(error).toBeInstanceOf(ExaError);
     expect(error.statusCode).toBe(400);
     expect(error.message).toBe("Bad Request. Invalid query");
     expect(error.path).toBe("/json-error");
+    expect(error.type).toBeUndefined();
+    expect(error.code).toBeUndefined();
+  });
+
+  it("unwraps agent-style nested error envelopes instead of '[object Object]'", async () => {
+    const error = (await exa
+      .request("/agent-error", "POST")
+      .catch((e) => e)) as ExaError;
+    expect(error).toBeInstanceOf(ExaError);
+    expect(error.statusCode).toBe(409);
+    expect(error.message).toBe(
+      "Idempotency-Key was already used for a different request"
+    );
+    expect(error.message).not.toContain("[object Object]");
+    expect(error.type).toBe("CONFLICT");
+    expect(error.code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+    expect(error.requestId).toBe("req_e2e123");
+    expect(error.path).toBe("/agent-error");
+  });
+
+  it("falls back to the error code when a nested envelope has no message", async () => {
+    const error = (await exa
+      .request("/agent-error-no-message", "GET")
+      .catch((e) => e)) as ExaError;
+    expect(error).toBeInstanceOf(ExaError);
+    expect(error.statusCode).toBe(404);
+    expect(error.message).toBe("MONITOR_NOT_FOUND");
+    expect(error.type).toBe("NOT_FOUND");
+    expect(error.code).toBe("MONITOR_NOT_FOUND");
+    expect(error.requestId).toBeUndefined();
   });
 
   it("returns parsed JSON for a normal successful response", async () => {


### PR DESCRIPTION
## Problem

Agent endpoints (`/agent/runs`, `/agent/monitors`, `/agent/monitors/snapshot`) return errors as a nested envelope:

```json
{
  "error": {
    "type": "CONFLICT",
    "code": "IDEMPOTENCY_KEY_CONFLICT",
    "message": "Idempotency-Key was already used for a different request"
  },
  "requestId": "..."
}
```

`Exa.request` built the thrown message by string-concatenating `errorData.error`, which is an object here, so `ExaError.message` became `[object Object]` and the API's detail was unreachable:

```ts
let message = errorData.error || "Unknown error";
```

Search/contents endpoints return `{"error": "<string>", ...}`, so they were unaffected — this only hit the agent surface (e.g. `exa.agent.runs.get("agentrun_doesnotexist")` lost `Run not found.`).

## Fix

In the `!response.ok` branch, handle an object-valued `error`:
- `ExaError.message` now carries the nested `error.message` (falling back to `code`, then `type`, then `"Unknown error"`).
- New optional `ExaError` fields `type`, `code`, and `requestId` preserve the structured envelope (`ExaErrorDetails` exported). The constructor change is backward-compatible (optional 5th param).
- The legacy string envelope (`{ error: "Bad Request", message: "Invalid query" }` → `"Bad Request. Invalid query"`) behaves exactly as before, with `type`/`code` left `undefined`.

## Before / after

```ts
try {
  await exa.agent.monitors.create(bodyB, { idempotencyKey: "k" }); // key already used with bodyA
} catch (e) {
  const err = e as ExaError;
  err.statusCode; // 409 (was already correct)
  err.message;    // was: "[object Object]"
                  // now: "Idempotency-Key was already used for a different request"
  err.type;       // "CONFLICT"
  err.code;       // "IDEMPOTENCY_KEY_CONFLICT"
  err.requestId;  // "req_..."
}
```

## Testing

- New cases in `test/unit/request-error-handling.test.ts` (runs against a real local HTTP server): nested envelope with message + `requestId`, nested envelope without message (falls back to code), and an assertion that the legacy string envelope is byte-for-byte unchanged with `type`/`code` undefined.
- `npm run test:unit`: 137/137 pass. `npm run build` clean. `npm run typecheck`: 44 errors, down from 47 pre-existing on master (this PR adds none and fixes three).

Pre-existing bug, not introduced by any single endpoint addition; found while running end-to-end tests of the Agent Monitors client (#201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)