### PR TITLE
feat(agent): add max effort and budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,19 @@ console.log(completedRun.output?.structured);
 console.log(completedRun.usage?.dataSources, completedRun.costDollars?.dataSources);
 ```
 
+For Agent Max, use the beta namespace and pass the beta token explicitly:
+
+```ts
+import { AGENT_MAX_EFFORT_BETA } from "exa-js";
+
+const maxRun = await exa.beta.agent.runs.create({
+  query: "Find all companies building browser automation tools in the United States.",
+  effort: "max",
+  budget: { maxCostDollars: 10 },
+  betas: [AGENT_MAX_EFFORT_BETA],
+});
+```
+
 ## TypeScript
 
 Full TypeScript support with types for all methods.

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -17,6 +17,7 @@ export type { AgentWaitOptions } from "./client";
 export type {
   AgentCostDollars,
   AgentBetaOptions,
+  AgentBudget,
   AgentCreateOptions,
   AgentConfidence,
   AgentDataSource,
@@ -42,4 +43,4 @@ export type {
   ListAgentRunsResponse,
 } from "./types";
 
-export { AGENT_BETA_HEADER } from "./types";
+export { AGENT_BETA_HEADER, AGENT_MAX_EFFORT_BETA } from "./types";

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -10,6 +10,8 @@ import { ZodSchema } from "zod";
  */
 export const AGENT_BETA_HEADER = "agent-2026-05-07";
 
+export const AGENT_MAX_EFFORT_BETA = "agent-max-effort-2026-07-27";
+
 export interface AgentBetaOptions {
   /**
    * @deprecated Agent API beta header is no longer required for `exa.agent`.
@@ -33,7 +35,24 @@ export type AgentStopReason =
 
 export type AgentConfidence = "low" | "medium" | "high";
 
-export type AgentEffort = "low" | "medium" | "high" | "xhigh" | "auto";
+export type AgentEffort =
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "auto"
+  | "max";
+
+/** Per-run spend ceiling for the metered `auto` and `max` efforts. */
+export interface AgentBudget {
+  /**
+   * Maximum spend for the run in US dollars.
+   * Only accepted by the API for `auto` and `max`; the server validates the
+   * allowed range and applies defaults when omitted.
+   */
+  maxCostDollars?: number;
+}
 
 /**
  * Identifier of an Exa Connect data provider, e.g. `"fiber_ai"`,
@@ -170,6 +189,7 @@ export interface CreateAgentRunParams {
   input?: AgentInput;
   outputSchema?: Record<string, unknown>;
   effort?: AgentEffort;
+  budget?: AgentBudget;
   previousRunId?: string;
   metadata?: Record<string, unknown>;
   /** Exa Connect data providers to enable for the run. Each entry enables all of that provider's tools. */

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -13,6 +13,7 @@ import {
   AgentBetaClient,
   AgentClient,
   AGENT_BETA_HEADER,
+  AGENT_MAX_EFFORT_BETA,
   BetaClient,
   AgentRunCancelledError,
   AgentRunFailedError,
@@ -189,6 +190,32 @@ describe("Agent API", () => {
       { query: "Find recent funding rounds." },
       undefined,
       { "Exa-Beta": AGENT_BETA_HEADER }
+    );
+  });
+
+  it("sends Agent Max beta values and budget through the beta namespace", async () => {
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(createMockRun());
+
+    await exa.beta.agent.runs.create({
+      betas: [AGENT_MAX_EFFORT_BETA],
+      query: "Find recent funding rounds.",
+      effort: "max",
+      budget: { maxCostDollars: 10 },
+    });
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      "",
+      "POST",
+      {
+        query: "Find recent funding rounds.",
+        effort: "max",
+        budget: { maxCostDollars: 10 },
+      },
+      undefined,
+      { "Exa-Beta": AGENT_MAX_EFFORT_BETA }
     );
   });
 


### PR DESCRIPTION
## Summary

- add `minimal` and `max` Agent effort values
- add an optional per-run `budget.maxCostDollars` field
- export the Agent Max beta token and document beta-namespace usage
- verify beta header and budget forwarding in the Agent client

## Why

Agent Max is beta-gated and requires SDK callers to pass the beta token explicitly. The SDK also needs to expose the metered effort budget used by `auto` and `max` runs.

## Impact

Consumers can opt into Agent Max through `exa.beta.agent.runs.create` with typed effort and budget parameters. Existing Agent calls are unchanged.

## Validation

- `vitest run --config vitest.unit.config.ts`: 136 tests passed
- focused Agent unit suite: 33 tests passed
- `git diff --check`: passed
- `tsc --noEmit`: existing unrelated errors remain in examples and legacy test fixtures; no errors were reported in the changed files
