### PR TITLE
feat: add Agent Monitors API support (exa.agent.monitors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ const run = await exa.agent.runs.create({
 const completedRun = await exa.agent.runs.pollUntilFinished(run.id);
 console.log(completedRun.output?.structured);
 // Per-provider tool-call counts and cost for any Exa Connect data sources used.
-console.log(completedRun.usage?.dataSources, completedRun.costDollars?.dataSources);
+console.log(
+  completedRun.usage?.dataSources,
+  completedRun.costDollars?.dataSources
+);
 ```
 
 For Agent Max, use the beta namespace and pass the beta token explicitly:
@@ -169,17 +172,18 @@ const maxRun = await exa.beta.agent.runs.create({
 });
 ```
 
-## Agent Monitors
+## Agent Monitors (Beta)
 
-> Agent Monitors are gated while in preview — contact Exa to enable them for your team.
+Agent Monitors use the beta namespace and require the `agent-monitors-2026-08-04` beta identifier.
 
 An Agent Monitor keeps a table of entities × fields fresh on a cadence: static fields are answered once per entity over the live web, dynamic fields are tracked from news on every refresh.
 
 ```ts
 // Create a monitor. Creation is async: it returns with status "creating"
 // and becomes "active" once the first refresh completes.
-const monitor = await exa.agent.monitors.create(
+const monitor = await exa.beta.agent.monitors.create(
   {
+    betas: ["agent-monitors-2026-08-04"],
     cadence: "7d",
     entities: [
       { name: "Acme Corp", domain: "acme.com" },
@@ -194,33 +198,45 @@ const monitor = await exa.agent.monitors.create(
 );
 
 // Page the monitor's current entities and their contents.
-for await (const { entity, contents } of exa.agent.monitors.entities.listAll(
-  monitor.id
-)) {
+for await (const {
+  entity,
+  contents,
+} of exa.beta.agent.monitors.entities.listAll(monitor.id, {
+  betas: ["agent-monitors-2026-08-04"],
+})) {
   console.log(entity.name, contents);
 }
 
 // Follow the content change feed (resume later from the page's nextCursor).
-const changes = await exa.agent.monitors.changes.list(monitor.id, {
+const changes = await exa.beta.agent.monitors.changes.list(monitor.id, {
+  betas: ["agent-monitors-2026-08-04"],
   since: "2026-01-01T00:00:00Z",
 });
 
 // One-shot stateless snapshot of a past news window — no monitor created.
-const snapshot = await exa.agent.monitors.snapshots.createAndWait({
+const snapshot = await exa.beta.agent.monitors.snapshots.createAndWait({
+  betas: ["agent-monitors-2026-08-04"],
   entities: [{ name: "Acme Corp", domain: "acme.com" }],
-  fields: [{ name: "funding", description: "New funding rounds", type: "dynamic" }],
+  fields: [
+    { name: "funding", description: "New funding rounds", type: "dynamic" },
+  ],
   startDate: "2026-01-01",
   endDate: "2026-01-08",
 });
 console.log(snapshot.data);
 
 // Add entities, inspect refresh progress, clean up.
-await exa.agent.monitors.entities.add(monitor.id, {
+await exa.beta.agent.monitors.entities.add(monitor.id, {
+  betas: ["agent-monitors-2026-08-04"],
   entities: [{ name: "Initech", domain: "initech.com" }],
 });
-const current = await exa.agent.monitors.get(monitor.id);
+const current = await exa.beta.agent.monitors.get(monitor.id, {
+  betas: ["agent-monitors-2026-08-04"],
+});
 console.log(current.status, current.refresh, current.usage);
-await exa.agent.monitors.delete(monitor.id);
+await exa.beta.agent.monitors.delete(monitor.id, {
+  betas: ["agent-monitors-2026-08-04"],
+});
 ```
 
 ## TypeScript

--- a/README.md
+++ b/README.md
@@ -169,6 +169,60 @@ const maxRun = await exa.beta.agent.runs.create({
 });
 ```
 
+## Agent Monitors
+
+> Agent Monitors are gated while in preview — contact Exa to enable them for your team.
+
+An Agent Monitor keeps a table of entities × fields fresh on a cadence: static fields are answered once per entity over the live web, dynamic fields are tracked from news on every refresh.
+
+```ts
+// Create a monitor. Creation is async: it returns with status "creating"
+// and becomes "active" once the first refresh completes.
+const monitor = await exa.agent.monitors.create(
+  {
+    cadence: "7d",
+    entities: [
+      { name: "Acme Corp", domain: "acme.com" },
+      { name: "Globex", domain: "globex.com" },
+    ],
+    fields: [
+      { name: "ceo", description: "The company's current CEO" }, // static by default
+      { name: "funding", description: "New funding rounds", type: "dynamic" },
+    ],
+  },
+  { idempotencyKey: "my-monitor-1" } // safe retries: same key returns the same monitor
+);
+
+// Page the monitor's current entities and their contents.
+for await (const { entity, contents } of exa.agent.monitors.entities.listAll(
+  monitor.id
+)) {
+  console.log(entity.name, contents);
+}
+
+// Follow the content change feed (resume later from the page's nextCursor).
+const changes = await exa.agent.monitors.changes.list(monitor.id, {
+  since: "2026-01-01T00:00:00Z",
+});
+
+// One-shot stateless snapshot of a past news window — no monitor created.
+const snapshot = await exa.agent.monitors.snapshots.createAndWait({
+  entities: [{ name: "Acme Corp", domain: "acme.com" }],
+  fields: [{ name: "funding", description: "New funding rounds", type: "dynamic" }],
+  startDate: "2026-01-01",
+  endDate: "2026-01-08",
+});
+console.log(snapshot.data);
+
+// Add entities, inspect refresh progress, clean up.
+await exa.agent.monitors.entities.add(monitor.id, {
+  entities: [{ name: "Initech", domain: "initech.com" }],
+});
+const current = await exa.agent.monitors.get(monitor.id);
+console.log(current.status, current.refresh, current.usage);
+await exa.agent.monitors.delete(monitor.id);
+```
+
 ## TypeScript
 
 Full TypeScript support with types for all methods.

--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ For Agent Max, use the beta namespace and pass the beta token explicitly:
 import { AGENT_MAX_EFFORT_BETA } from "exa-js";
 
 const maxRun = await exa.beta.agent.runs.create({
-  query: "Find all companies building browser automation tools in the United States.",
+  query:
+    "Find all companies building browser automation tools in the United States.",
   effort: "max",
   budget: { maxCostDollars: 10 },
   betas: [AGENT_MAX_EFFORT_BETA],
@@ -174,16 +175,20 @@ const maxRun = await exa.beta.agent.runs.create({
 
 ## Agent Monitors (Beta)
 
-Agent Monitors use the beta namespace and require the `agent-monitors-2026-08-04` beta identifier.
+Agent Monitors use the beta namespace and require the `AGENT_MONITORS_BETA_HEADER` beta identifier (`agent-monitors-2026-08-04`).
 
 An Agent Monitor keeps a table of entities × fields fresh on a cadence: static fields are answered once per entity over the live web, dynamic fields are tracked from news on every refresh.
 
 ```ts
+import { AGENT_MONITORS_BETA_HEADER } from "exa-js";
+
+const betas = [AGENT_MONITORS_BETA_HEADER];
+
 // Create a monitor. Creation is async: it returns with status "creating"
 // and becomes "active" once the first refresh completes.
 const monitor = await exa.beta.agent.monitors.create(
   {
-    betas: ["agent-monitors-2026-08-04"],
+    betas,
     cadence: "7d",
     entities: [
       { name: "Acme Corp", domain: "acme.com" },
@@ -201,21 +206,19 @@ const monitor = await exa.beta.agent.monitors.create(
 for await (const {
   entity,
   contents,
-} of exa.beta.agent.monitors.entities.listAll(monitor.id, {
-  betas: ["agent-monitors-2026-08-04"],
-})) {
+} of exa.beta.agent.monitors.entities.listAll(monitor.id, { betas })) {
   console.log(entity.name, contents);
 }
 
 // Follow the content change feed (resume later from the page's nextCursor).
 const changes = await exa.beta.agent.monitors.changes.list(monitor.id, {
-  betas: ["agent-monitors-2026-08-04"],
+  betas,
   since: "2026-01-01T00:00:00Z",
 });
 
 // One-shot stateless snapshot of a past news window — no monitor created.
 const snapshot = await exa.beta.agent.monitors.snapshots.createAndWait({
-  betas: ["agent-monitors-2026-08-04"],
+  betas,
   entities: [{ name: "Acme Corp", domain: "acme.com" }],
   fields: [
     { name: "funding", description: "New funding rounds", type: "dynamic" },
@@ -227,16 +230,12 @@ console.log(snapshot.data);
 
 // Add entities, inspect refresh progress, clean up.
 await exa.beta.agent.monitors.entities.add(monitor.id, {
-  betas: ["agent-monitors-2026-08-04"],
+  betas,
   entities: [{ name: "Initech", domain: "initech.com" }],
 });
-const current = await exa.beta.agent.monitors.get(monitor.id, {
-  betas: ["agent-monitors-2026-08-04"],
-});
+const current = await exa.beta.agent.monitors.get(monitor.id, { betas });
 console.log(current.status, current.refresh, current.usage);
-await exa.beta.agent.monitors.delete(monitor.id, {
-  betas: ["agent-monitors-2026-08-04"],
-});
+await exa.beta.agent.monitors.delete(monitor.id, { betas });
 ```
 
 ## TypeScript

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ const monitor = await exa.beta.agent.monitors.create(
       { name: "Globex", domain: "globex.com" },
     ],
     fields: [
-      { name: "ceo", description: "The company's current CEO" }, // static by default
-      { name: "funding", description: "New funding rounds", type: "dynamic" },
+      { name: "funding", description: "New funding rounds" }, // dynamic by default
+      { name: "ceo", description: "The company's current CEO", mode: "static" },
     ],
   },
   { idempotencyKey: "my-monitor-1" } // safe retries: same key returns the same monitor
@@ -221,7 +221,7 @@ const snapshot = await exa.beta.agent.monitors.snapshots.createAndWait({
   betas,
   entities: [{ name: "Acme Corp", domain: "acme.com" }],
   fields: [
-    { name: "funding", description: "New funding rounds", type: "dynamic" },
+    { name: "funding", description: "New funding rounds" }, // dynamic by default
   ],
   startDate: "2026-01-01",
   endDate: "2026-01-08",

--- a/src/agent/betas.ts
+++ b/src/agent/betas.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared Exa-Beta header construction for the agent API surfaces.
+ */
+
+export function headersForBetas(
+  betas?: string[]
+): Record<string, string> | undefined {
+  const betaValues = betas?.filter(Boolean);
+  if (!betaValues?.length) return undefined;
+  return { "Exa-Beta": betaValues.join(",") };
+}

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -7,6 +7,7 @@ import { Exa } from "../index";
 import { ExaError } from "../errors";
 import { isZodSchema, zodToJsonSchema } from "../zod-utils";
 import { AgentBaseClient } from "./base";
+import { headersForBetas } from "./betas";
 import { AgentMonitorsClient } from "./monitors/client";
 import {
   AgentBetaOptions,
@@ -63,12 +64,6 @@ export class AgentRunCancelledError extends Error {
     this.name = "AgentRunCancelledError";
     this.run = run;
   }
-}
-
-function headersForBetas(betas?: string[]): Record<string, string> | undefined {
-  const betaValues = betas?.filter(Boolean);
-  if (!betaValues?.length) return undefined;
-  return { "Exa-Beta": betaValues.join(",") };
 }
 
 function isTerminalAgentRunStatus(

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -7,6 +7,7 @@ import { Exa } from "../index";
 import { ExaError } from "../errors";
 import { isZodSchema, zodToJsonSchema } from "../zod-utils";
 import { AgentBaseClient } from "./base";
+import { AgentMonitorsClient } from "./monitors/client";
 import {
   AgentBetaOptions,
   AgentCreateOptions,
@@ -376,9 +377,15 @@ export class AgentClient {
    */
   runs: AgentRunsClient;
 
+  /**
+   * Client for Agent Monitors.
+   */
+  monitors: AgentMonitorsClient;
+
   constructor(client: Exa) {
     this.client = client;
     this.runs = new AgentRunsClient(client);
+    this.monitors = new AgentMonitorsClient(client);
   }
 }
 

--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -377,15 +377,9 @@ export class AgentClient {
    */
   runs: AgentRunsClient;
 
-  /**
-   * Client for Agent Monitors.
-   */
-  monitors: AgentMonitorsClient;
-
   constructor(client: Exa) {
     this.client = client;
     this.runs = new AgentRunsClient(client);
-    this.monitors = new AgentMonitorsClient(client);
   }
 }
 
@@ -608,14 +602,17 @@ export class AgentBetaRunsClient extends AgentRunsClient {
   }
 }
 
-/**
- * @deprecated Use AgentClient instead.
- */
+/** Beta Agent API clients. */
 export class AgentBetaClient extends AgentClient {
   /**
    * @deprecated Use exa.agent.runs instead.
    */
   runs: AgentBetaRunsClient;
+
+  /**
+   * Beta client for Agent Monitors.
+   */
+  monitors: AgentMonitorsClient;
 
   constructor(clientOrAgent: Exa | AgentClient) {
     const client =
@@ -624,12 +621,14 @@ export class AgentBetaClient extends AgentClient {
         : clientOrAgent;
     super(client);
     this.runs = new AgentBetaRunsClient(client);
+    this.monitors = new AgentMonitorsClient(client);
   }
 }
 
 export class BetaClient {
   /**
-   * @deprecated Use exa.agent instead.
+   * Beta Agent namespace. Stable Agent runs remain available here for
+   * backwards compatibility; beta-only Agent products live here exclusively.
    */
   agent: AgentBetaClient;
 

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -44,3 +44,5 @@ export type {
 } from "./types";
 
 export { AGENT_BETA_HEADER, AGENT_MAX_EFFORT_BETA } from "./types";
+
+export * from "./monitors";

--- a/src/agent/monitors/base.ts
+++ b/src/agent/monitors/base.ts
@@ -2,6 +2,7 @@
  * Base client for the Exa Agent Monitors API.
  */
 
+import { ExaError, HttpStatusCode } from "../../errors";
 import { Exa } from "../../index";
 import { headersForBetas } from "../betas";
 import {
@@ -34,8 +35,9 @@ export class AgentMonitorsBaseClient {
     headers?: Record<string, string>
   ): Promise<T> {
     if (!betas?.includes(AGENT_MONITORS_BETA_HEADER)) {
-      throw new Error(
-        `betas must include the Agent Monitors beta identifier ("${AGENT_MONITORS_BETA_HEADER}")`
+      throw new ExaError(
+        `betas must include the Agent Monitors beta identifier ("${AGENT_MONITORS_BETA_HEADER}")`,
+        HttpStatusCode.BadRequest
       );
     }
 

--- a/src/agent/monitors/base.ts
+++ b/src/agent/monitors/base.ts
@@ -1,0 +1,58 @@
+/**
+ * Base client for the Exa Agent Monitors API.
+ */
+
+import { Exa } from "../../index";
+import {
+  ListAgentMonitorChangesParams,
+  ListAgentMonitorEntitiesParams,
+  ListAgentMonitorsParams,
+} from "./types";
+
+type QueryParams = Record<
+  string,
+  string | number | boolean | string[] | undefined
+>;
+
+type RequestBody = Record<string, any>;
+
+export class AgentMonitorsBaseClient {
+  protected client: Exa;
+
+  constructor(client: Exa) {
+    this.client = client;
+  }
+
+  protected async request<T = unknown>(
+    endpoint: string,
+    method: string = "POST",
+    data?: RequestBody,
+    params?: QueryParams,
+    headers?: Record<string, string>
+  ): Promise<T> {
+    return this.client.request<T>(
+      `/agent/monitors${endpoint}`,
+      method,
+      data,
+      params,
+      headers
+    );
+  }
+
+  protected buildPaginationParams(
+    pagination?:
+      | ListAgentMonitorsParams
+      | ListAgentMonitorEntitiesParams
+      | ListAgentMonitorChangesParams
+  ): QueryParams {
+    const params: QueryParams = {};
+    if (!pagination) return params;
+
+    if (pagination.cursor) params.cursor = pagination.cursor;
+    if (pagination.limit) params.limit = pagination.limit;
+    if ("since" in pagination && pagination.since)
+      params.since = pagination.since;
+
+    return params;
+  }
+}

--- a/src/agent/monitors/base.ts
+++ b/src/agent/monitors/base.ts
@@ -3,7 +3,9 @@
  */
 
 import { Exa } from "../../index";
+import { headersForBetas } from "../betas";
 import {
+  AGENT_MONITORS_BETA_HEADER,
   ListAgentMonitorChangesParams,
   ListAgentMonitorEntitiesParams,
   ListAgentMonitorsParams,
@@ -31,9 +33,9 @@ export class AgentMonitorsBaseClient {
     params?: QueryParams,
     headers?: Record<string, string>
   ): Promise<T> {
-    if (!betas?.length) {
+    if (!betas?.includes(AGENT_MONITORS_BETA_HEADER)) {
       throw new Error(
-        "betas must include the Agent Monitors API beta identifier"
+        `betas must include the Agent Monitors beta identifier ("${AGENT_MONITORS_BETA_HEADER}")`
       );
     }
 
@@ -43,7 +45,7 @@ export class AgentMonitorsBaseClient {
       data,
       params,
       {
-        "Exa-Beta": betas.join(","),
+        ...headersForBetas(betas),
         ...headers,
       }
     );

--- a/src/agent/monitors/base.ts
+++ b/src/agent/monitors/base.ts
@@ -25,17 +25,27 @@ export class AgentMonitorsBaseClient {
 
   protected async request<T = unknown>(
     endpoint: string,
+    betas: string[],
     method: string = "POST",
     data?: RequestBody,
     params?: QueryParams,
     headers?: Record<string, string>
   ): Promise<T> {
+    if (!betas?.length) {
+      throw new Error(
+        "betas must include the Agent Monitors API beta identifier"
+      );
+    }
+
     return this.client.request<T>(
       `/agent/monitors${endpoint}`,
       method,
       data,
       params,
-      headers
+      {
+        "Exa-Beta": betas.join(","),
+        ...headers,
+      }
     );
   }
 

--- a/src/agent/monitors/client.ts
+++ b/src/agent/monitors/client.ts
@@ -11,6 +11,7 @@ import {
   AgentMonitorEntityView,
   AgentMonitorSnapshot,
   AgentMonitorSnapshotWaitOptions,
+  AgentMonitorsBetaOptions,
   CreateAgentMonitorOptions,
   CreateAgentMonitorParams,
   CreateAgentMonitorSnapshotParams,
@@ -51,9 +52,15 @@ export class AgentMonitorEntitiesClient extends AgentMonitorsBaseClient {
    */
   async add(
     monitorId: string,
-    params: AddAgentMonitorEntitiesParams
+    params: AddAgentMonitorEntitiesParams & AgentMonitorsBetaOptions
   ): Promise<AgentMonitor> {
-    return this.request<AgentMonitor>(`/${monitorId}/entities`, "POST", params);
+    const { betas, ...payload } = params;
+    return this.request<AgentMonitor>(
+      `/${monitorId}/entities`,
+      betas,
+      "POST",
+      payload
+    );
   }
 
   /**
@@ -62,11 +69,13 @@ export class AgentMonitorEntitiesClient extends AgentMonitorsBaseClient {
    */
   async list(
     monitorId: string,
-    options?: ListAgentMonitorEntitiesParams
+    options: ListAgentMonitorEntitiesParams & AgentMonitorsBetaOptions
   ): Promise<ListAgentMonitorEntitiesResponse> {
-    const params = this.buildPaginationParams(options);
+    const { betas, ...pagination } = options;
+    const params = this.buildPaginationParams(pagination);
     return this.request<ListAgentMonitorEntitiesResponse>(
       `/${monitorId}/entities`,
+      betas,
       "GET",
       undefined,
       params
@@ -79,14 +88,15 @@ export class AgentMonitorEntitiesClient extends AgentMonitorsBaseClient {
    */
   async *listAll(
     monitorId: string,
-    options?: ListAgentMonitorEntitiesParams
+    options: ListAgentMonitorEntitiesParams & AgentMonitorsBetaOptions
   ): AsyncGenerator<AgentMonitorEntityView> {
     let cursor: string | undefined = undefined;
-    const pageOptions = options ? { ...options } : {};
+    const { betas, ...pagination } = options;
+    const pageOptions: ListAgentMonitorEntitiesParams = { ...pagination };
 
     while (true) {
       pageOptions.cursor = cursor;
-      const response = await this.list(monitorId, pageOptions);
+      const response = await this.list(monitorId, { ...pageOptions, betas });
 
       for (const entityView of response.data) {
         yield entityView;
@@ -105,7 +115,7 @@ export class AgentMonitorEntitiesClient extends AgentMonitorsBaseClient {
    */
   async getAll(
     monitorId: string,
-    options?: ListAgentMonitorEntitiesParams
+    options: ListAgentMonitorEntitiesParams & AgentMonitorsBetaOptions
   ): Promise<AgentMonitorEntityView[]> {
     const entities: AgentMonitorEntityView[] = [];
     for await (const entityView of this.listAll(monitorId, options)) {
@@ -121,11 +131,13 @@ export class AgentMonitorChangesClient extends AgentMonitorsBaseClient {
    */
   async list(
     monitorId: string,
-    options?: ListAgentMonitorChangesParams
+    options: ListAgentMonitorChangesParams & AgentMonitorsBetaOptions
   ): Promise<ListAgentMonitorChangesResponse> {
-    const params = this.buildPaginationParams(options);
+    const { betas, ...pagination } = options;
+    const params = this.buildPaginationParams(pagination);
     return this.request<ListAgentMonitorChangesResponse>(
       `/${monitorId}/changes`,
+      betas,
       "GET",
       undefined,
       params
@@ -138,14 +150,15 @@ export class AgentMonitorChangesClient extends AgentMonitorsBaseClient {
    */
   async *listAll(
     monitorId: string,
-    options?: ListAgentMonitorChangesParams
+    options: ListAgentMonitorChangesParams & AgentMonitorsBetaOptions
   ): AsyncGenerator<AgentMonitorChange> {
     let cursor: string | undefined = options?.cursor;
-    const pageOptions = options ? { ...options } : {};
+    const { betas, ...pagination } = options;
+    const pageOptions: ListAgentMonitorChangesParams = { ...pagination };
 
     while (true) {
       pageOptions.cursor = cursor;
-      const response = await this.list(monitorId, pageOptions);
+      const response = await this.list(monitorId, { ...pageOptions, betas });
 
       for (const change of response.data) {
         yield change;
@@ -164,7 +177,7 @@ export class AgentMonitorChangesClient extends AgentMonitorsBaseClient {
    */
   async getAll(
     monitorId: string,
-    options?: ListAgentMonitorChangesParams
+    options: ListAgentMonitorChangesParams & AgentMonitorsBetaOptions
   ): Promise<AgentMonitorChange[]> {
     const changes: AgentMonitorChange[] = [];
     for await (const change of this.listAll(monitorId, options)) {
@@ -181,17 +194,30 @@ export class AgentMonitorSnapshotsClient extends AgentMonitorsBaseClient {
    * with `get` (or use `createAndWait`) for the result.
    */
   async create(
-    params: CreateAgentMonitorSnapshotParams
+    params: CreateAgentMonitorSnapshotParams & AgentMonitorsBetaOptions
   ): Promise<AgentMonitorSnapshot> {
-    return this.request<AgentMonitorSnapshot>("/snapshot", "POST", params);
+    const { betas, ...payload } = params;
+    return this.request<AgentMonitorSnapshot>(
+      "/snapshot",
+      betas,
+      "POST",
+      payload
+    );
   }
 
   /**
    * Poll a snapshot job for its status and, once completed, its result.
    * Jobs expire and read as 404 after `expiresAt`.
    */
-  async get(snapshotId: string): Promise<AgentMonitorSnapshot> {
-    return this.request<AgentMonitorSnapshot>(`/snapshot/${snapshotId}`, "GET");
+  async get(
+    snapshotId: string,
+    options: AgentMonitorsBetaOptions
+  ): Promise<AgentMonitorSnapshot> {
+    return this.request<AgentMonitorSnapshot>(
+      `/snapshot/${snapshotId}`,
+      options.betas,
+      "GET"
+    );
   }
 
   /**
@@ -199,7 +225,7 @@ export class AgentMonitorSnapshotsClient extends AgentMonitorsBaseClient {
    */
   async pollUntilFinished(
     snapshotId: string,
-    options?: AgentMonitorSnapshotWaitOptions
+    options: AgentMonitorSnapshotWaitOptions & AgentMonitorsBetaOptions
   ): Promise<AgentMonitorTerminalSnapshot> {
     const pollInterval =
       options?.pollInterval ?? DEFAULT_SNAPSHOT_POLL_INTERVAL_MS;
@@ -207,7 +233,7 @@ export class AgentMonitorSnapshotsClient extends AgentMonitorsBaseClient {
     const startTime = Date.now();
 
     while (true) {
-      const snapshot = await this.get(snapshotId);
+      const snapshot = await this.get(snapshotId, { betas: options.betas });
       if (snapshot.status !== "running") {
         return snapshot;
       }
@@ -227,13 +253,16 @@ export class AgentMonitorSnapshotsClient extends AgentMonitorsBaseClient {
    * AgentMonitorSnapshotFailedError if the snapshot fails.
    */
   async createAndWait(
-    params: CreateAgentMonitorSnapshotParams,
+    params: CreateAgentMonitorSnapshotParams & AgentMonitorsBetaOptions,
     options?: AgentMonitorSnapshotWaitOptions
   ): Promise<AgentMonitorCompletedSnapshot> {
     const snapshot = await this.create(params);
     const terminalSnapshot =
       snapshot.status === "running"
-        ? await this.pollUntilFinished(snapshot.id, options)
+        ? await this.pollUntilFinished(snapshot.id, {
+            ...options,
+            betas: params.betas,
+          })
         : snapshot;
     if (terminalSnapshot.status === "failed") {
       throw new AgentMonitorSnapshotFailedError(terminalSnapshot);
@@ -271,31 +300,44 @@ export class AgentMonitorsClient extends AgentMonitorsBaseClient {
    * becomes `active` once its first refresh completes.
    */
   async create(
-    params: CreateAgentMonitorParams,
+    params: CreateAgentMonitorParams & AgentMonitorsBetaOptions,
     options?: CreateAgentMonitorOptions
   ): Promise<AgentMonitor> {
+    const { betas, ...payload } = params;
     const headers = options?.idempotencyKey
       ? { "Idempotency-Key": options.idempotencyKey }
       : undefined;
-    return this.request<AgentMonitor>("", "POST", params, undefined, headers);
+    return this.request<AgentMonitor>(
+      "",
+      betas,
+      "POST",
+      payload,
+      undefined,
+      headers
+    );
   }
 
   /**
    * Get an Agent Monitor by ID, including refresh progress.
    */
-  async get(monitorId: string): Promise<AgentMonitor> {
-    return this.request<AgentMonitor>(`/${monitorId}`, "GET");
+  async get(
+    monitorId: string,
+    options: AgentMonitorsBetaOptions
+  ): Promise<AgentMonitor> {
+    return this.request<AgentMonitor>(`/${monitorId}`, options.betas, "GET");
   }
 
   /**
    * List the team's Agent Monitors.
    */
   async list(
-    options?: ListAgentMonitorsParams
+    options: ListAgentMonitorsParams & AgentMonitorsBetaOptions
   ): Promise<ListAgentMonitorsResponse> {
-    const params = this.buildPaginationParams(options);
+    const { betas, ...pagination } = options;
+    const params = this.buildPaginationParams(pagination);
     return this.request<ListAgentMonitorsResponse>(
       "",
+      betas,
       "GET",
       undefined,
       params
@@ -306,14 +348,15 @@ export class AgentMonitorsClient extends AgentMonitorsBaseClient {
    * Iterate through all Agent Monitors, handling pagination automatically.
    */
   async *listAll(
-    options?: ListAgentMonitorsParams
+    options: ListAgentMonitorsParams & AgentMonitorsBetaOptions
   ): AsyncGenerator<AgentMonitor> {
     let cursor: string | undefined = undefined;
-    const pageOptions = options ? { ...options } : {};
+    const { betas, ...pagination } = options;
+    const pageOptions: ListAgentMonitorsParams = { ...pagination };
 
     while (true) {
       pageOptions.cursor = cursor;
-      const response = await this.list(pageOptions);
+      const response = await this.list({ ...pageOptions, betas });
 
       for (const monitor of response.data) {
         yield monitor;
@@ -330,7 +373,9 @@ export class AgentMonitorsClient extends AgentMonitorsBaseClient {
   /**
    * Collect all Agent Monitors into an array.
    */
-  async getAll(options?: ListAgentMonitorsParams): Promise<AgentMonitor[]> {
+  async getAll(
+    options: ListAgentMonitorsParams & AgentMonitorsBetaOptions
+  ): Promise<AgentMonitor[]> {
     const monitors: AgentMonitor[] = [];
     for await (const monitor of this.listAll(options)) {
       monitors.push(monitor);
@@ -341,7 +386,14 @@ export class AgentMonitorsClient extends AgentMonitorsBaseClient {
   /**
    * Delete an Agent Monitor and stop its refreshes.
    */
-  async delete(monitorId: string): Promise<DeletedAgentMonitor> {
-    return this.request<DeletedAgentMonitor>(`/${monitorId}`, "DELETE");
+  async delete(
+    monitorId: string,
+    options: AgentMonitorsBetaOptions
+  ): Promise<DeletedAgentMonitor> {
+    return this.request<DeletedAgentMonitor>(
+      `/${monitorId}`,
+      options.betas,
+      "DELETE"
+    );
   }
 }

--- a/src/agent/monitors/client.ts
+++ b/src/agent/monitors/client.ts
@@ -90,7 +90,7 @@ export class AgentMonitorEntitiesClient extends AgentMonitorsBaseClient {
     monitorId: string,
     options: ListAgentMonitorEntitiesParams & AgentMonitorsBetaOptions
   ): AsyncGenerator<AgentMonitorEntityView> {
-    let cursor: string | undefined = undefined;
+    let cursor: string | undefined = options.cursor;
     const { betas, ...pagination } = options;
     const pageOptions: ListAgentMonitorEntitiesParams = { ...pagination };
 
@@ -152,7 +152,7 @@ export class AgentMonitorChangesClient extends AgentMonitorsBaseClient {
     monitorId: string,
     options: ListAgentMonitorChangesParams & AgentMonitorsBetaOptions
   ): AsyncGenerator<AgentMonitorChange> {
-    let cursor: string | undefined = options?.cursor;
+    let cursor: string | undefined = options.cursor;
     const { betas, ...pagination } = options;
     const pageOptions: ListAgentMonitorChangesParams = { ...pagination };
 
@@ -228,8 +228,8 @@ export class AgentMonitorSnapshotsClient extends AgentMonitorsBaseClient {
     options: AgentMonitorSnapshotWaitOptions & AgentMonitorsBetaOptions
   ): Promise<AgentMonitorTerminalSnapshot> {
     const pollInterval =
-      options?.pollInterval ?? DEFAULT_SNAPSHOT_POLL_INTERVAL_MS;
-    const timeoutMs = options?.timeoutMs ?? DEFAULT_SNAPSHOT_POLL_TIMEOUT_MS;
+      options.pollInterval ?? DEFAULT_SNAPSHOT_POLL_INTERVAL_MS;
+    const timeoutMs = options.timeoutMs ?? DEFAULT_SNAPSHOT_POLL_TIMEOUT_MS;
     const startTime = Date.now();
 
     while (true) {
@@ -350,7 +350,7 @@ export class AgentMonitorsClient extends AgentMonitorsBaseClient {
   async *listAll(
     options: ListAgentMonitorsParams & AgentMonitorsBetaOptions
   ): AsyncGenerator<AgentMonitor> {
-    let cursor: string | undefined = undefined;
+    let cursor: string | undefined = options.cursor;
     const { betas, ...pagination } = options;
     const pageOptions: ListAgentMonitorsParams = { ...pagination };
 

--- a/src/agent/monitors/client.ts
+++ b/src/agent/monitors/client.ts
@@ -1,0 +1,347 @@
+/**
+ * Client for the Exa Agent Monitors API (`/agent/monitors`).
+ */
+
+import { Exa } from "../../index";
+import { AgentMonitorsBaseClient } from "./base";
+import {
+  AddAgentMonitorEntitiesParams,
+  AgentMonitor,
+  AgentMonitorChange,
+  AgentMonitorEntityView,
+  AgentMonitorSnapshot,
+  AgentMonitorSnapshotWaitOptions,
+  CreateAgentMonitorOptions,
+  CreateAgentMonitorParams,
+  CreateAgentMonitorSnapshotParams,
+  DeletedAgentMonitor,
+  ListAgentMonitorChangesParams,
+  ListAgentMonitorChangesResponse,
+  ListAgentMonitorEntitiesParams,
+  ListAgentMonitorEntitiesResponse,
+  ListAgentMonitorsParams,
+  ListAgentMonitorsResponse,
+} from "./types";
+
+const DEFAULT_SNAPSHOT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_SNAPSHOT_POLL_TIMEOUT_MS = 60 * 60 * 1000;
+
+type AgentMonitorTerminalSnapshot = AgentMonitorSnapshot & {
+  status: "completed" | "failed";
+};
+type AgentMonitorCompletedSnapshot = AgentMonitorSnapshot & {
+  status: "completed";
+};
+
+export class AgentMonitorSnapshotFailedError extends Error {
+  snapshot: AgentMonitorSnapshot & { status: "failed" };
+
+  constructor(snapshot: AgentMonitorSnapshot & { status: "failed" }) {
+    super(snapshot.error ?? `Agent monitor snapshot ${snapshot.id} failed`);
+    this.name = "AgentMonitorSnapshotFailedError";
+    this.snapshot = snapshot;
+  }
+}
+
+export class AgentMonitorEntitiesClient extends AgentMonitorsBaseClient {
+  /**
+   * Add entities to an existing Agent Monitor. Added entities are resolved
+   * and backfilled shortly after the request completes, then update on the
+   * monitor's regular refresh cadence.
+   */
+  async add(
+    monitorId: string,
+    params: AddAgentMonitorEntitiesParams
+  ): Promise<AgentMonitor> {
+    return this.request<AgentMonitor>(`/${monitorId}/entities`, "POST", params);
+  }
+
+  /**
+   * Page an Agent Monitor's current entities and contents, optionally
+   * filtered by update time.
+   */
+  async list(
+    monitorId: string,
+    options?: ListAgentMonitorEntitiesParams
+  ): Promise<ListAgentMonitorEntitiesResponse> {
+    const params = this.buildPaginationParams(options);
+    return this.request<ListAgentMonitorEntitiesResponse>(
+      `/${monitorId}/entities`,
+      "GET",
+      undefined,
+      params
+    );
+  }
+
+  /**
+   * Iterate through all of a monitor's entities, handling pagination
+   * automatically.
+   */
+  async *listAll(
+    monitorId: string,
+    options?: ListAgentMonitorEntitiesParams
+  ): AsyncGenerator<AgentMonitorEntityView> {
+    let cursor: string | undefined = undefined;
+    const pageOptions = options ? { ...options } : {};
+
+    while (true) {
+      pageOptions.cursor = cursor;
+      const response = await this.list(monitorId, pageOptions);
+
+      for (const entityView of response.data) {
+        yield entityView;
+      }
+
+      if (!response.hasMore || !response.nextCursor) {
+        break;
+      }
+
+      cursor = response.nextCursor;
+    }
+  }
+
+  /**
+   * Collect all of a monitor's entities into an array.
+   */
+  async getAll(
+    monitorId: string,
+    options?: ListAgentMonitorEntitiesParams
+  ): Promise<AgentMonitorEntityView[]> {
+    const entities: AgentMonitorEntityView[] = [];
+    for await (const entityView of this.listAll(monitorId, options)) {
+      entities.push(entityView);
+    }
+    return entities;
+  }
+}
+
+export class AgentMonitorChangesClient extends AgentMonitorsBaseClient {
+  /**
+   * Page an Agent Monitor's content change feed since a cursor or timestamp.
+   */
+  async list(
+    monitorId: string,
+    options?: ListAgentMonitorChangesParams
+  ): Promise<ListAgentMonitorChangesResponse> {
+    const params = this.buildPaginationParams(options);
+    return this.request<ListAgentMonitorChangesResponse>(
+      `/${monitorId}/changes`,
+      "GET",
+      undefined,
+      params
+    );
+  }
+
+  /**
+   * Iterate through a monitor's change feed, handling pagination
+   * automatically.
+   */
+  async *listAll(
+    monitorId: string,
+    options?: ListAgentMonitorChangesParams
+  ): AsyncGenerator<AgentMonitorChange> {
+    let cursor: string | undefined = options?.cursor;
+    const pageOptions = options ? { ...options } : {};
+
+    while (true) {
+      pageOptions.cursor = cursor;
+      const response = await this.list(monitorId, pageOptions);
+
+      for (const change of response.data) {
+        yield change;
+      }
+
+      if (!response.hasMore || !response.nextCursor) {
+        break;
+      }
+
+      cursor = response.nextCursor;
+    }
+  }
+
+  /**
+   * Collect a monitor's change feed into an array.
+   */
+  async getAll(
+    monitorId: string,
+    options?: ListAgentMonitorChangesParams
+  ): Promise<AgentMonitorChange[]> {
+    const changes: AgentMonitorChange[] = [];
+    for await (const change of this.listAll(monitorId, options)) {
+      changes.push(change);
+    }
+    return changes;
+  }
+}
+
+export class AgentMonitorSnapshotsClient extends AgentMonitorsBaseClient {
+  /**
+   * Start an async, stateless snapshot of entities × fields over an explicit
+   * past news window — no monitor is created. Returns a `running` job; poll
+   * with `get` (or use `createAndWait`) for the result.
+   */
+  async create(
+    params: CreateAgentMonitorSnapshotParams
+  ): Promise<AgentMonitorSnapshot> {
+    return this.request<AgentMonitorSnapshot>("/snapshot", "POST", params);
+  }
+
+  /**
+   * Poll a snapshot job for its status and, once completed, its result.
+   * Jobs expire and read as 404 after `expiresAt`.
+   */
+  async get(snapshotId: string): Promise<AgentMonitorSnapshot> {
+    return this.request<AgentMonitorSnapshot>(`/snapshot/${snapshotId}`, "GET");
+  }
+
+  /**
+   * Poll a snapshot job until it reaches a terminal status.
+   */
+  async pollUntilFinished(
+    snapshotId: string,
+    options?: AgentMonitorSnapshotWaitOptions
+  ): Promise<AgentMonitorTerminalSnapshot> {
+    const pollInterval =
+      options?.pollInterval ?? DEFAULT_SNAPSHOT_POLL_INTERVAL_MS;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_SNAPSHOT_POLL_TIMEOUT_MS;
+    const startTime = Date.now();
+
+    while (true) {
+      const snapshot = await this.get(snapshotId);
+      if (snapshot.status !== "running") {
+        return snapshot;
+      }
+
+      if (Date.now() - startTime > timeoutMs) {
+        throw new Error(
+          `Polling timeout: Agent monitor snapshot ${snapshotId} did not complete within ${timeoutMs}ms`
+        );
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+  }
+
+  /**
+   * Start a snapshot and wait for its result. Throws
+   * AgentMonitorSnapshotFailedError if the snapshot fails.
+   */
+  async createAndWait(
+    params: CreateAgentMonitorSnapshotParams,
+    options?: AgentMonitorSnapshotWaitOptions
+  ): Promise<AgentMonitorCompletedSnapshot> {
+    const snapshot = await this.create(params);
+    const terminalSnapshot =
+      snapshot.status === "running"
+        ? await this.pollUntilFinished(snapshot.id, options)
+        : snapshot;
+    if (terminalSnapshot.status === "failed") {
+      throw new AgentMonitorSnapshotFailedError(terminalSnapshot);
+    }
+    return terminalSnapshot as AgentMonitorCompletedSnapshot;
+  }
+}
+
+export class AgentMonitorsClient extends AgentMonitorsBaseClient {
+  /**
+   * Client for a monitor's entities.
+   */
+  entities: AgentMonitorEntitiesClient;
+
+  /**
+   * Client for a monitor's content change feed.
+   */
+  changes: AgentMonitorChangesClient;
+
+  /**
+   * Client for stateless snapshot jobs.
+   */
+  snapshots: AgentMonitorSnapshotsClient;
+
+  constructor(client: Exa) {
+    super(client);
+    this.entities = new AgentMonitorEntitiesClient(client);
+    this.changes = new AgentMonitorChangesClient(client);
+    this.snapshots = new AgentMonitorSnapshotsClient(client);
+  }
+
+  /**
+   * Create an Agent Monitor from its entities, fields, and cadence.
+   * Creation is async: the monitor is returned with status `creating` and
+   * becomes `active` once its first refresh completes.
+   */
+  async create(
+    params: CreateAgentMonitorParams,
+    options?: CreateAgentMonitorOptions
+  ): Promise<AgentMonitor> {
+    const headers = options?.idempotencyKey
+      ? { "Idempotency-Key": options.idempotencyKey }
+      : undefined;
+    return this.request<AgentMonitor>("", "POST", params, undefined, headers);
+  }
+
+  /**
+   * Get an Agent Monitor by ID, including refresh progress.
+   */
+  async get(monitorId: string): Promise<AgentMonitor> {
+    return this.request<AgentMonitor>(`/${monitorId}`, "GET");
+  }
+
+  /**
+   * List the team's Agent Monitors.
+   */
+  async list(
+    options?: ListAgentMonitorsParams
+  ): Promise<ListAgentMonitorsResponse> {
+    const params = this.buildPaginationParams(options);
+    return this.request<ListAgentMonitorsResponse>(
+      "",
+      "GET",
+      undefined,
+      params
+    );
+  }
+
+  /**
+   * Iterate through all Agent Monitors, handling pagination automatically.
+   */
+  async *listAll(
+    options?: ListAgentMonitorsParams
+  ): AsyncGenerator<AgentMonitor> {
+    let cursor: string | undefined = undefined;
+    const pageOptions = options ? { ...options } : {};
+
+    while (true) {
+      pageOptions.cursor = cursor;
+      const response = await this.list(pageOptions);
+
+      for (const monitor of response.data) {
+        yield monitor;
+      }
+
+      if (!response.hasMore || !response.nextCursor) {
+        break;
+      }
+
+      cursor = response.nextCursor;
+    }
+  }
+
+  /**
+   * Collect all Agent Monitors into an array.
+   */
+  async getAll(options?: ListAgentMonitorsParams): Promise<AgentMonitor[]> {
+    const monitors: AgentMonitor[] = [];
+    for await (const monitor of this.listAll(options)) {
+      monitors.push(monitor);
+    }
+    return monitors;
+  }
+
+  /**
+   * Delete an Agent Monitor and stop its refreshes.
+   */
+  async delete(monitorId: string): Promise<DeletedAgentMonitor> {
+    return this.request<DeletedAgentMonitor>(`/${monitorId}`, "DELETE");
+  }
+}

--- a/src/agent/monitors/index.ts
+++ b/src/agent/monitors/index.ts
@@ -1,0 +1,8 @@
+export {
+  AgentMonitorChangesClient,
+  AgentMonitorEntitiesClient,
+  AgentMonitorSnapshotFailedError,
+  AgentMonitorSnapshotsClient,
+  AgentMonitorsClient,
+} from "./client";
+export * from "./types";

--- a/src/agent/monitors/types.ts
+++ b/src/agent/monitors/types.ts
@@ -1,0 +1,278 @@
+/**
+ * Types for the Exa Agent Monitors API (`/agent/monitors`).
+ *
+ * An Agent Monitor keeps a table of entities × fields fresh: static fields
+ * are answered once per entity over the live web, dynamic fields are tracked
+ * from news on every refresh, on the monitor's cadence.
+ */
+
+export type AgentMonitorStatus =
+  | "creating"
+  | "pending_first_refresh"
+  | "active";
+
+export type AgentMonitorFieldType = "static" | "dynamic";
+
+/**
+ * A field the monitor keeps fresh for every entity. Fields are static
+ * (answered once over the live web) unless declared `type: "dynamic"`
+ * (tracked from news on every refresh).
+ */
+export interface AgentMonitorField {
+  id: string;
+  name: string;
+  description: string;
+  type: AgentMonitorFieldType;
+}
+
+/** An entity tracked by the monitor. */
+export interface AgentMonitorEntity {
+  id: string;
+  name: string;
+  domain?: string;
+  canonicalEntityId?: string;
+}
+
+/** One cell value: a field's current content for an entity. */
+export interface AgentMonitorContent {
+  value: unknown;
+  sourceUrls?: string[];
+  updatedAt: string;
+}
+
+/** Refresh progress on the monitor object; `idle` outside an active refresh. */
+export type AgentMonitorRefresh =
+  | { state: "idle" }
+  | {
+      state: "running";
+      entitiesProcessed: number;
+      entitiesTotal: number;
+      startedAt: string;
+    };
+
+/** Creation progress on the monitor object; `idle` once the monitor is set up. */
+export type AgentMonitorCreation =
+  | { state: "idle" }
+  | {
+      state: "running";
+      entitiesProcessed: number;
+      entitiesTotal: number;
+      startedAt: string;
+    };
+
+/** ACU consumption on the monitor object; ACUs are the unit Agent runs bill in. */
+export interface AgentMonitorUsage {
+  /** Lifetime ACUs consumed by the monitor's refreshes (creation's first refresh included). */
+  totalAcus: number;
+  /** ACUs consumed by the most recently completed refresh run. */
+  lastRefreshAcus: number;
+}
+
+export interface AgentMonitor {
+  id: string;
+  object: "agent_monitor";
+  status: AgentMonitorStatus;
+  /** Refresh cadence, e.g. `"12h"` or `"7d"`; also each refresh's lookback window. */
+  cadence: string;
+  fields: AgentMonitorField[];
+  entityCount: number;
+  version: number;
+  createdAt: string;
+  lastRefreshAt: string | null;
+  refresh: AgentMonitorRefresh;
+  creation: AgentMonitorCreation;
+  usage: AgentMonitorUsage;
+  sourceRunId?: string;
+}
+
+/** One entity and its current contents, keyed by field id. */
+export interface AgentMonitorEntityView {
+  entity: AgentMonitorEntity;
+  contents: Record<string, AgentMonitorContent>;
+}
+
+/**
+ * Entity/field references on a change item. `id` is the canonical, stable
+ * join key; the name attributes are denormalized for display, resolved as of
+ * read time, and absent when the entity/field no longer exists.
+ */
+export interface AgentMonitorChangeEntity {
+  id: string;
+  name?: string;
+  domain?: string;
+  canonicalEntityId?: string;
+}
+
+export interface AgentMonitorChangeField {
+  id: string;
+  name?: string;
+}
+
+/** One content change from the monitor's change feed. */
+export interface AgentMonitorChange {
+  type: "content.upserted";
+  entity: AgentMonitorChangeEntity;
+  field: AgentMonitorChangeField;
+  content: AgentMonitorContent;
+  version: number;
+  /** ISO-8601 commit time of the change event. */
+  createdAt: string;
+}
+
+// --- Request params ---
+
+/** An entity to track. `domain` anchors entity resolution and must be unique per monitor. */
+export interface CreateAgentMonitorEntityParams {
+  name: string;
+  /** Resolution anchor: entities resolve by first-party or domain-verified evidence. */
+  domain: string;
+  /** Extra disambiguation context for entity resolution of ambiguous names. */
+  description?: string;
+}
+
+/** A field to keep fresh. Static (the default) unless declared `type: "dynamic"`. */
+export interface CreateAgentMonitorFieldParams {
+  name: string;
+  description: string;
+  type?: AgentMonitorFieldType;
+}
+
+export interface CreateAgentMonitorParams {
+  /**
+   * How often the monitor refreshes, e.g. `"12h"` or `"7d"` (minimum 6h).
+   * Also each refresh's news lookback window.
+   */
+  cadence: string;
+  entities: CreateAgentMonitorEntityParams[];
+  fields: CreateAgentMonitorFieldParams[];
+}
+
+export interface CreateAgentMonitorOptions {
+  /**
+   * Sent as the `Idempotency-Key` header. A retried create with the same key
+   * returns the monitor the first attempt created (resuming any unfinished
+   * entity ingestion) instead of creating a duplicate. Reusing a key with a
+   * different body is a 409.
+   */
+  idempotencyKey?: string;
+}
+
+export interface ListAgentMonitorsParams {
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ListAgentMonitorEntitiesParams {
+  cursor?: string;
+  limit?: number;
+  /** Only return entities whose contents were updated at or after this ISO-8601 timestamp. */
+  since?: string;
+}
+
+export interface ListAgentMonitorChangesParams {
+  cursor?: string;
+  limit?: number;
+  /** Only return changes committed at or after this ISO-8601 timestamp. */
+  since?: string;
+}
+
+export interface AddAgentMonitorEntitiesParams {
+  entities: CreateAgentMonitorEntityParams[];
+}
+
+// --- Responses ---
+
+export interface ListAgentMonitorsResponse {
+  object: "list";
+  data: AgentMonitor[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+
+export interface ListAgentMonitorEntitiesResponse {
+  object: "list";
+  data: AgentMonitorEntityView[];
+  hasMore: boolean;
+  nextCursor: string | null;
+  /** Store head change token — "am I caught up?" display only, NOT the cursor. */
+  version: number;
+}
+
+export interface ListAgentMonitorChangesResponse {
+  object: "list";
+  data: AgentMonitorChange[];
+  hasMore: boolean;
+  /** Opaque; resume the feed from the last served change. Null when data is empty. */
+  nextCursor: string | null;
+  /** Store head change token — "am I caught up?" display only, NOT the cursor. */
+  version: number;
+}
+
+export interface DeletedAgentMonitor {
+  id: string;
+  object: "agent_monitor.deleted";
+  deleted: true;
+}
+
+// --- Snapshots ---
+
+/**
+ * Params for a one-shot, stateless snapshot of entities × fields over an
+ * explicit past news window — no monitor is created. The window bounds
+ * dynamic fields only; static fields return present values answered over the
+ * live web, and the result carries a warning when static fields are included.
+ */
+export interface CreateAgentMonitorSnapshotParams {
+  entities: CreateAgentMonitorEntityParams[];
+  fields: CreateAgentMonitorFieldParams[];
+  /** Start of the news window to snapshot, `YYYY-MM-DD` (UTC). */
+  startDate: string;
+  /** Hour of startDate the window starts at, 0-23 UTC; omitted means midnight. */
+  startHour?: number;
+  /** End of the news window to snapshot, `YYYY-MM-DD` (UTC). */
+  endDate: string;
+  /** Hour of endDate the window ends at, 0-23 UTC; omitted means midnight. */
+  endHour?: number;
+}
+
+/** One entity's snapshot result: populated field values plus the news sources read. */
+export interface AgentMonitorSnapshotEntity {
+  name: string;
+  /** Populated values by field name; fields with no update are absent. */
+  fields: Record<string, string>;
+  sourceUrls: string[];
+}
+
+/** The computed body of a finished snapshot, embedded in the job once it completes. */
+export interface AgentMonitorSnapshotResult {
+  data: AgentMonitorSnapshotEntity[];
+  failedEntities?: Array<{ name: string; reason: string }>;
+  /** Caveats about how the snapshot was computed, e.g. static fields ignoring the window. */
+  warnings?: string[];
+}
+
+export type AgentMonitorSnapshotStatus = "running" | "completed" | "failed";
+
+/**
+ * A snapshot job: `create` returns it as `running`, and `get` polls it to
+ * `completed` (result fields present) or `failed`. Jobs expire and read as
+ * 404 after `expiresAt`.
+ */
+export type AgentMonitorSnapshot = {
+  id: string;
+  object: "agent_monitor.snapshot";
+  /** The snapshotted news window, echoed back as normalized ISO-8601 timestamps. */
+  startTime: string;
+  endTime: string;
+  createdAt: string;
+  expiresAt: string;
+} & (
+  | { status: "running" }
+  | ({ status: "completed" } & AgentMonitorSnapshotResult)
+  | { status: "failed"; error: string }
+);
+
+export interface AgentMonitorSnapshotWaitOptions {
+  pollInterval?: number;
+  timeoutMs?: number;
+}

--- a/src/agent/monitors/types.ts
+++ b/src/agent/monitors/types.ts
@@ -6,6 +6,14 @@
  * from news on every refresh, on the monitor's cadence.
  */
 
+/** Beta identifier required for the Agent Monitors API. */
+export const AGENT_MONITORS_BETA_HEADER = "agent-monitors-2026-08-04";
+
+export interface AgentMonitorsBetaOptions {
+  /** Beta feature identifiers to enable for this request. */
+  betas: string[];
+}
+
 export type AgentMonitorStatus =
   | "creating"
   | "pending_first_refresh"

--- a/src/agent/monitors/types.ts
+++ b/src/agent/monitors/types.ts
@@ -19,18 +19,23 @@ export type AgentMonitorStatus =
   | "pending_first_refresh"
   | "active";
 
-export type AgentMonitorFieldType = "static" | "dynamic";
+export type AgentMonitorFieldMode = "static" | "dynamic";
+
+/** @deprecated Renamed to {@link AgentMonitorFieldMode}. */
+export type AgentMonitorFieldType = AgentMonitorFieldMode;
 
 /**
- * A field the monitor keeps fresh for every entity. Fields are static
- * (answered once over the live web) unless declared `type: "dynamic"`
- * (tracked from news on every refresh).
+ * A field the monitor keeps fresh for every entity. Fields are dynamic
+ * (tracked from news on every refresh) unless declared `mode: "static"`
+ * (answered once over the live web).
  */
 export interface AgentMonitorField {
   id: string;
   name: string;
   description: string;
-  type: AgentMonitorFieldType;
+  mode: AgentMonitorFieldMode;
+  /** @deprecated Renamed to `mode`; echoes the same value until removed. */
+  type: AgentMonitorFieldMode;
 }
 
 /** An entity tracked by the monitor. */
@@ -138,11 +143,13 @@ export interface CreateAgentMonitorEntityParams {
   description?: string;
 }
 
-/** A field to keep fresh. Static (the default) unless declared `type: "dynamic"`. */
+/** A field to keep fresh. Dynamic (the default) unless declared `mode: "static"`. */
 export interface CreateAgentMonitorFieldParams {
   name: string;
   description: string;
-  type?: AgentMonitorFieldType;
+  mode?: AgentMonitorFieldMode;
+  /** @deprecated Renamed to `mode`; declare one spelling, not both. */
+  type?: AgentMonitorFieldMode;
 }
 
 export interface CreateAgentMonitorParams {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,6 +13,32 @@ export enum HttpStatusCode {
 }
 
 /**
+ * Structured fields from the API's error envelope
+ * (e.g. `{ "error": { "type", "code", "message", "detail" }, "requestId" }`).
+ */
+export interface ExaErrorEnvelope {
+  /**
+   * Error category, e.g. "NOT_FOUND", "INVALID_REQUEST", "CONFLICT"
+   */
+  type?: string;
+
+  /**
+   * Specific error code, e.g. "MONITOR_NOT_FOUND"
+   */
+  code?: string;
+
+  /**
+   * Additional context, e.g. which validation rule failed
+   */
+  detail?: unknown;
+
+  /**
+   * Server-side request id for support/debugging
+   */
+  requestId?: string;
+}
+
+/**
  * Base error class for all Exa API errors
  */
 export class ExaError extends Error {
@@ -32,22 +58,50 @@ export class ExaError extends Error {
   path?: string;
 
   /**
+   * Error category from the API's error envelope, e.g. "NOT_FOUND"
+   */
+  type?: string;
+
+  /**
+   * Specific error code from the API's error envelope, e.g. "MONITOR_NOT_FOUND"
+   */
+  code?: string;
+
+  /**
+   * Additional context from the API's error envelope
+   */
+  detail?: unknown;
+
+  /**
+   * Server-side request id for support/debugging
+   */
+  requestId?: string;
+
+  /**
    * Create a new ExaError
    * @param message Error message
    * @param statusCode HTTP status code
    * @param timestamp ISO timestamp from API
    * @param path Path that caused the error
+   * @param envelope Structured fields from the API's error envelope
    */
   constructor(
     message: string,
     statusCode: number,
     timestamp?: string,
-    path?: string
+    path?: string,
+    envelope?: ExaErrorEnvelope
   ) {
     super(message);
     this.name = "ExaError";
     this.statusCode = statusCode;
     this.timestamp = timestamp ?? new Date().toISOString();
     this.path = path;
+    if (envelope) {
+      this.type = envelope.type;
+      this.code = envelope.code;
+      this.detail = envelope.detail;
+      this.requestId = envelope.requestId;
+    }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -954,16 +954,42 @@ export class Exa {
         errorData.path = endpoint;
       }
 
-      // For other APIs, throw a simple ExaError with just message and status
-      let message = errorData.error || "Unknown error";
-      if (errorData.message) {
-        message += (message.length > 0 ? ". " : "") + errorData.message;
+      // Structured envelope (`error` is an object): message and metadata live
+      // inside it — e.g. { error: { type, code, message, detail }, requestId }.
+      const envelope =
+        typeof errorData.error === "object" && errorData.error !== null
+          ? (errorData.error as {
+              type?: string;
+              code?: string;
+              message?: string;
+              detail?: unknown;
+              requestId?: string;
+            })
+          : undefined;
+      let message: string;
+      if (envelope) {
+        message = envelope.message || errorData.message || "Unknown error";
+      } else {
+        message = errorData.error || "Unknown error";
+        if (errorData.message) {
+          message += (message.length > 0 ? ". " : "") + errorData.message;
+        }
       }
       throw new ExaError(
         message,
         response.status,
         errorData.timestamp,
-        errorData.path
+        errorData.path,
+        envelope
+          ? {
+              type: envelope.type,
+              code: envelope.code,
+              detail: envelope.detail,
+              requestId: errorData.requestId ?? envelope.requestId,
+            }
+          : errorData.requestId
+            ? { requestId: errorData.requestId }
+            : undefined
       );
     }
 

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -123,7 +123,17 @@ describe("Agent Monitors API", () => {
       await expect(
         exa.beta.agent.monitors.get("agentmon_01hzx3example", { betas: [] })
       ).rejects.toThrow(
-        "betas must include the Agent Monitors API beta identifier"
+        'betas must include the Agent Monitors beta identifier ("agent-monitors-2026-08-04")'
+      );
+    });
+
+    it("rejects a beta list that lacks the monitors beta identifier", async () => {
+      await expect(
+        exa.beta.agent.monitors.get("agentmon_01hzx3example", {
+          betas: ["some-other-beta"],
+        })
+      ).rejects.toThrow(
+        'betas must include the Agent Monitors beta identifier ("agent-monitors-2026-08-04")'
       );
     });
 
@@ -284,6 +294,30 @@ describe("Agent Monitors API", () => {
       });
     });
 
+    it("should resume listAll from a provided cursor", async () => {
+      const page: ListAgentMonitorsResponse = {
+        object: "list",
+        data: [createMockMonitor({ id: "agentmon_2" })],
+        hasMore: false,
+        nextCursor: null,
+      };
+
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(page);
+
+      const monitors = await exa.beta.agent.monitors.getAll({
+        cursor: "agentmon_1",
+        betas: BETAS,
+      });
+
+      expect(monitors.map((monitor) => monitor.id)).toEqual(["agentmon_2"]);
+      expect(requestSpy).toHaveBeenCalledWith("", BETAS, "GET", undefined, {
+        cursor: "agentmon_1",
+      });
+    });
+
     it("should delete an Agent Monitor", async () => {
       const mockResponse: DeletedAgentMonitor = {
         id: "agentmon_01hzx3example",
@@ -406,6 +440,37 @@ describe("Agent Monitors API", () => {
       expect(entities).toHaveLength(2);
       expect(requestSpy).toHaveBeenCalledTimes(2);
       expect(requestSpy).toHaveBeenLastCalledWith(
+        "/agentmon_01hzx3example/entities",
+        BETAS,
+        "GET",
+        undefined,
+        { cursor: "cursor-2" }
+      );
+    });
+
+    it("should resume entities listAll from a provided cursor", async () => {
+      const page: ListAgentMonitorEntitiesResponse = {
+        object: "list",
+        data: [createMockEntityView()],
+        hasMore: false,
+        nextCursor: null,
+        version: 3,
+      };
+
+      const entitiesClient = getProtectedClient(
+        exa.beta.agent.monitors.entities
+      );
+      const requestSpy = vi
+        .spyOn(entitiesClient, "request")
+        .mockResolvedValueOnce(page);
+
+      const entities = await exa.beta.agent.monitors.entities.getAll(
+        "agentmon_01hzx3example",
+        { cursor: "cursor-2", betas: BETAS }
+      );
+
+      expect(entities).toHaveLength(1);
+      expect(requestSpy).toHaveBeenCalledWith(
         "/agentmon_01hzx3example/entities",
         BETAS,
         "GET",

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Exa from "../../src";
+import { ExaError } from "../../src/errors";
 import { AgentMonitorSnapshotFailedError } from "../../src/agent/monitors/client";
 import {
   AgentMonitor,
@@ -119,20 +120,26 @@ describe("Agent Monitors API", () => {
       );
     });
 
-    it("rejects an empty beta list", async () => {
-      await expect(
-        exa.beta.agent.monitors.get("agentmon_01hzx3example", { betas: [] })
-      ).rejects.toThrow(
+    it("rejects an empty beta list with an ExaError", async () => {
+      const error = await exa.beta.agent.monitors
+        .get("agentmon_01hzx3example", { betas: [] })
+        .then(() => undefined)
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ExaError);
+      expect((error as ExaError).statusCode).toBe(400);
+      expect((error as ExaError).message).toBe(
         'betas must include the Agent Monitors beta identifier ("agent-monitors-2026-08-04")'
       );
     });
 
-    it("rejects a beta list that lacks the monitors beta identifier", async () => {
-      await expect(
-        exa.beta.agent.monitors.get("agentmon_01hzx3example", {
-          betas: ["some-other-beta"],
-        })
-      ).rejects.toThrow(
+    it("rejects a beta list that lacks the monitors beta identifier with an ExaError", async () => {
+      const error = await exa.beta.agent.monitors
+        .get("agentmon_01hzx3example", { betas: ["some-other-beta"] })
+        .then(() => undefined)
+        .catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(ExaError);
+      expect((error as ExaError).statusCode).toBe(400);
+      expect((error as ExaError).message).toBe(
         'betas must include the Agent Monitors beta identifier ("agent-monitors-2026-08-04")'
       );
     });

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -17,6 +17,7 @@ import { getProtectedClient } from "./helpers";
 
 describe("Agent Monitors API", () => {
   let exa: Exa;
+  const BETAS = ["agent-monitors-2026-08-04"];
 
   const createMockMonitor = (
     overrides: Partial<AgentMonitor> = {}
@@ -97,10 +98,39 @@ describe("Agent Monitors API", () => {
   });
 
   describe("Monitor Operations", () => {
+    it("exposes monitors only in beta and sends beta values as headers", async () => {
+      expect((exa.agent as any).monitors).toBeUndefined();
+      expect(exa.beta.agent.monitors).toBeDefined();
+
+      const requestSpy = vi
+        .spyOn(exa, "request")
+        .mockResolvedValueOnce(createMockMonitor());
+
+      await exa.beta.agent.monitors.get("agentmon_01hzx3example", {
+        betas: BETAS,
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/agent/monitors/agentmon_01hzx3example",
+        "GET",
+        undefined,
+        undefined,
+        { "Exa-Beta": "agent-monitors-2026-08-04" }
+      );
+    });
+
+    it("rejects an empty beta list", async () => {
+      await expect(
+        exa.beta.agent.monitors.get("agentmon_01hzx3example", { betas: [] })
+      ).rejects.toThrow(
+        "betas must include the Agent Monitors API beta identifier"
+      );
+    });
+
     it("should create an Agent Monitor", async () => {
       const mockResponse = createMockMonitor({ status: "creating" });
 
-      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
       const requestSpy = vi
         .spyOn(monitorsClient, "request")
         .mockResolvedValueOnce(mockResponse);
@@ -125,10 +155,14 @@ describe("Agent Monitors API", () => {
         ],
       };
 
-      const result = await exa.agent.monitors.create(createParams);
+      const result = await exa.beta.agent.monitors.create({
+        ...createParams,
+        betas: BETAS,
+      });
 
       expect(requestSpy).toHaveBeenCalledWith(
         "",
+        BETAS,
         "POST",
         createParams,
         undefined,
@@ -141,7 +175,7 @@ describe("Agent Monitors API", () => {
     it("should send the Idempotency-Key header when creating with idempotencyKey", async () => {
       const mockResponse = createMockMonitor({ status: "creating" });
 
-      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
       const requestSpy = vi
         .spyOn(monitorsClient, "request")
         .mockResolvedValueOnce(mockResponse);
@@ -152,12 +186,16 @@ describe("Agent Monitors API", () => {
         fields: [{ name: "ceo", description: "The company's current CEO" }],
       };
 
-      await exa.agent.monitors.create(createParams, {
-        idempotencyKey: "my-key-1",
-      });
+      await exa.beta.agent.monitors.create(
+        { ...createParams, betas: BETAS },
+        {
+          idempotencyKey: "my-key-1",
+        }
+      );
 
       expect(requestSpy).toHaveBeenCalledWith(
         "",
+        BETAS,
         "POST",
         createParams,
         undefined,
@@ -170,14 +208,21 @@ describe("Agent Monitors API", () => {
     it("should get an Agent Monitor by ID", async () => {
       const mockResponse = createMockMonitor();
 
-      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
       const requestSpy = vi
         .spyOn(monitorsClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.get("agentmon_01hzx3example");
+      const result = await exa.beta.agent.monitors.get(
+        "agentmon_01hzx3example",
+        { betas: BETAS }
+      );
 
-      expect(requestSpy).toHaveBeenCalledWith("/agentmon_01hzx3example", "GET");
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/agentmon_01hzx3example",
+        BETAS,
+        "GET"
+      );
       expect(result).toEqual(mockResponse);
     });
 
@@ -189,17 +234,18 @@ describe("Agent Monitors API", () => {
         nextCursor: null,
       };
 
-      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
       const requestSpy = vi
         .spyOn(monitorsClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.list({
+      const result = await exa.beta.agent.monitors.list({
+        betas: BETAS,
         cursor: "agentmon_01hzxcursor",
         limit: 10,
       });
 
-      expect(requestSpy).toHaveBeenCalledWith("", "GET", undefined, {
+      expect(requestSpy).toHaveBeenCalledWith("", BETAS, "GET", undefined, {
         cursor: "agentmon_01hzxcursor",
         limit: 10,
       });
@@ -220,20 +266,20 @@ describe("Agent Monitors API", () => {
         nextCursor: null,
       };
 
-      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
       const requestSpy = vi
         .spyOn(monitorsClient, "request")
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
-      const monitors = await exa.agent.monitors.getAll();
+      const monitors = await exa.beta.agent.monitors.getAll({ betas: BETAS });
 
       expect(monitors.map((monitor) => monitor.id)).toEqual([
         "agentmon_1",
         "agentmon_2",
       ]);
       expect(requestSpy).toHaveBeenCalledTimes(2);
-      expect(requestSpy).toHaveBeenLastCalledWith("", "GET", undefined, {
+      expect(requestSpy).toHaveBeenLastCalledWith("", BETAS, "GET", undefined, {
         cursor: "agentmon_1",
       });
     });
@@ -245,15 +291,19 @@ describe("Agent Monitors API", () => {
         deleted: true,
       };
 
-      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const monitorsClient = getProtectedClient(exa.beta.agent.monitors);
       const requestSpy = vi
         .spyOn(monitorsClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.delete("agentmon_01hzx3example");
+      const result = await exa.beta.agent.monitors.delete(
+        "agentmon_01hzx3example",
+        { betas: BETAS }
+      );
 
       expect(requestSpy).toHaveBeenCalledWith(
         "/agentmon_01hzx3example",
+        BETAS,
         "DELETE"
       );
       expect(result).toEqual(mockResponse);
@@ -264,7 +314,9 @@ describe("Agent Monitors API", () => {
     it("should add entities to a monitor", async () => {
       const mockResponse = createMockMonitor({ entityCount: 3 });
 
-      const entitiesClient = getProtectedClient(exa.agent.monitors.entities);
+      const entitiesClient = getProtectedClient(
+        exa.beta.agent.monitors.entities
+      );
       const requestSpy = vi
         .spyOn(entitiesClient, "request")
         .mockResolvedValueOnce(mockResponse);
@@ -272,13 +324,14 @@ describe("Agent Monitors API", () => {
       const params = {
         entities: [{ name: "Initech", domain: "initech.com" }],
       };
-      const result = await exa.agent.monitors.entities.add(
+      const result = await exa.beta.agent.monitors.entities.add(
         "agentmon_01hzx3example",
-        params
+        { ...params, betas: BETAS }
       );
 
       expect(requestSpy).toHaveBeenCalledWith(
         "/agentmon_01hzx3example/entities",
+        BETAS,
         "POST",
         params
       );
@@ -294,18 +347,26 @@ describe("Agent Monitors API", () => {
         version: 3,
       };
 
-      const entitiesClient = getProtectedClient(exa.agent.monitors.entities);
+      const entitiesClient = getProtectedClient(
+        exa.beta.agent.monitors.entities
+      );
       const requestSpy = vi
         .spyOn(entitiesClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.entities.list(
+      const result = await exa.beta.agent.monitors.entities.list(
         "agentmon_01hzx3example",
-        { cursor: "abc", limit: 50, since: "2026-01-07T00:00:00.000Z" }
+        {
+          betas: BETAS,
+          cursor: "abc",
+          limit: 50,
+          since: "2026-01-07T00:00:00.000Z",
+        }
       );
 
       expect(requestSpy).toHaveBeenCalledWith(
         "/agentmon_01hzx3example/entities",
+        BETAS,
         "GET",
         undefined,
         { cursor: "abc", limit: 50, since: "2026-01-07T00:00:00.000Z" }
@@ -329,20 +390,24 @@ describe("Agent Monitors API", () => {
         version: 3,
       };
 
-      const entitiesClient = getProtectedClient(exa.agent.monitors.entities);
+      const entitiesClient = getProtectedClient(
+        exa.beta.agent.monitors.entities
+      );
       const requestSpy = vi
         .spyOn(entitiesClient, "request")
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
-      const entities = await exa.agent.monitors.entities.getAll(
-        "agentmon_01hzx3example"
+      const entities = await exa.beta.agent.monitors.entities.getAll(
+        "agentmon_01hzx3example",
+        { betas: BETAS }
       );
 
       expect(entities).toHaveLength(2);
       expect(requestSpy).toHaveBeenCalledTimes(2);
       expect(requestSpy).toHaveBeenLastCalledWith(
         "/agentmon_01hzx3example/entities",
+        BETAS,
         "GET",
         undefined,
         { cursor: "cursor-2" }
@@ -360,18 +425,19 @@ describe("Agent Monitors API", () => {
         version: 3,
       };
 
-      const changesClient = getProtectedClient(exa.agent.monitors.changes);
+      const changesClient = getProtectedClient(exa.beta.agent.monitors.changes);
       const requestSpy = vi
         .spyOn(changesClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.changes.list(
+      const result = await exa.beta.agent.monitors.changes.list(
         "agentmon_01hzx3example",
-        { since: "2026-01-07T00:00:00.000Z" }
+        { betas: BETAS, since: "2026-01-07T00:00:00.000Z" }
       );
 
       expect(requestSpy).toHaveBeenCalledWith(
         "/agentmon_01hzx3example/changes",
+        BETAS,
         "GET",
         undefined,
         { since: "2026-01-07T00:00:00.000Z" }
@@ -396,21 +462,22 @@ describe("Agent Monitors API", () => {
         version: 3,
       };
 
-      const changesClient = getProtectedClient(exa.agent.monitors.changes);
+      const changesClient = getProtectedClient(exa.beta.agent.monitors.changes);
       const requestSpy = vi
         .spyOn(changesClient, "request")
         .mockResolvedValueOnce(firstPage)
         .mockResolvedValueOnce(secondPage);
 
-      const changes = await exa.agent.monitors.changes.getAll(
+      const changes = await exa.beta.agent.monitors.changes.getAll(
         "agentmon_01hzx3example",
-        { cursor: "change-cursor-1" }
+        { betas: BETAS, cursor: "change-cursor-1" }
       );
 
       expect(changes).toHaveLength(2);
       expect(requestSpy).toHaveBeenNthCalledWith(
         1,
         "/agentmon_01hzx3example/changes",
+        BETAS,
         "GET",
         undefined,
         { cursor: "change-cursor-1" }
@@ -418,6 +485,7 @@ describe("Agent Monitors API", () => {
       expect(requestSpy).toHaveBeenNthCalledWith(
         2,
         "/agentmon_01hzx3example/changes",
+        BETAS,
         "GET",
         undefined,
         { cursor: "change-cursor-2" }
@@ -439,15 +507,21 @@ describe("Agent Monitors API", () => {
     it("should start a snapshot job", async () => {
       const mockResponse = runningSnapshot;
 
-      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const snapshotsClient = getProtectedClient(
+        exa.beta.agent.monitors.snapshots
+      );
       const requestSpy = vi
         .spyOn(snapshotsClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.snapshots.create(snapshotParams);
+      const result = await exa.beta.agent.monitors.snapshots.create({
+        ...snapshotParams,
+        betas: BETAS,
+      });
 
       expect(requestSpy).toHaveBeenCalledWith(
         "/snapshot",
+        BETAS,
         "POST",
         snapshotParams
       );
@@ -468,17 +542,21 @@ describe("Agent Monitors API", () => {
         warnings: [],
       };
 
-      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const snapshotsClient = getProtectedClient(
+        exa.beta.agent.monitors.snapshots
+      );
       const requestSpy = vi
         .spyOn(snapshotsClient, "request")
         .mockResolvedValueOnce(mockResponse);
 
-      const result = await exa.agent.monitors.snapshots.get(
-        "agentsnap_01hzx3snap1"
+      const result = await exa.beta.agent.monitors.snapshots.get(
+        "agentsnap_01hzx3snap1",
+        { betas: BETAS }
       );
 
       expect(requestSpy).toHaveBeenCalledWith(
         "/snapshot/agentsnap_01hzx3snap1",
+        BETAS,
         "GET"
       );
       expect(result.status).toBe("completed");
@@ -494,14 +572,16 @@ describe("Agent Monitors API", () => {
         data: [],
       };
 
-      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const snapshotsClient = getProtectedClient(
+        exa.beta.agent.monitors.snapshots
+      );
       vi.spyOn(snapshotsClient, "request")
         .mockResolvedValueOnce(runningSnapshot)
         .mockResolvedValueOnce(runningSnapshot)
         .mockResolvedValueOnce(completed);
 
-      const result = await exa.agent.monitors.snapshots.createAndWait(
-        snapshotParams,
+      const result = await exa.beta.agent.monitors.snapshots.createAndWait(
+        { ...snapshotParams, betas: BETAS },
         { pollInterval: 1 }
       );
 
@@ -515,26 +595,32 @@ describe("Agent Monitors API", () => {
         error: "newsfeed unavailable",
       };
 
-      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const snapshotsClient = getProtectedClient(
+        exa.beta.agent.monitors.snapshots
+      );
       vi.spyOn(snapshotsClient, "request")
         .mockResolvedValueOnce(runningSnapshot)
         .mockResolvedValueOnce(failed);
 
       await expect(
-        exa.agent.monitors.snapshots.createAndWait(snapshotParams, {
-          pollInterval: 1,
-        })
+        exa.beta.agent.monitors.snapshots.createAndWait(
+          { ...snapshotParams, betas: BETAS },
+          { pollInterval: 1 }
+        )
       ).rejects.toThrow(AgentMonitorSnapshotFailedError);
     });
 
     it("should time out pollUntilFinished when the snapshot never finishes", async () => {
-      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const snapshotsClient = getProtectedClient(
+        exa.beta.agent.monitors.snapshots
+      );
       vi.spyOn(snapshotsClient, "request").mockResolvedValue(runningSnapshot);
 
       await expect(
-        exa.agent.monitors.snapshots.pollUntilFinished(
+        exa.beta.agent.monitors.snapshots.pollUntilFinished(
           "agentsnap_01hzx3snap1",
           {
+            betas: BETAS,
             pollInterval: 1,
             timeoutMs: 5,
           }

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -1,0 +1,545 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Exa from "../../src";
+import { AgentMonitorSnapshotFailedError } from "../../src/agent/monitors/client";
+import {
+  AgentMonitor,
+  AgentMonitorChange,
+  AgentMonitorEntityView,
+  AgentMonitorSnapshot,
+  CreateAgentMonitorParams,
+  CreateAgentMonitorSnapshotParams,
+  DeletedAgentMonitor,
+  ListAgentMonitorChangesResponse,
+  ListAgentMonitorEntitiesResponse,
+  ListAgentMonitorsResponse,
+} from "../../src/agent/monitors/types";
+import { getProtectedClient } from "./helpers";
+
+describe("Agent Monitors API", () => {
+  let exa: Exa;
+
+  const createMockMonitor = (
+    overrides: Partial<AgentMonitor> = {}
+  ): AgentMonitor => ({
+    id: "agentmon_01hzx3example",
+    object: "agent_monitor",
+    status: "active",
+    cadence: "7d",
+    fields: [
+      {
+        id: "agentfield_01hzx3field1",
+        name: "ceo",
+        description: "The company's current CEO",
+        type: "static",
+      },
+      {
+        id: "agentfield_01hzx3field2",
+        name: "funding",
+        description: "New funding rounds",
+        type: "dynamic",
+      },
+    ],
+    entityCount: 2,
+    version: 3,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    lastRefreshAt: "2026-01-08T00:00:00.000Z",
+    refresh: { state: "idle" },
+    creation: { state: "idle" },
+    usage: { totalAcus: 12, lastRefreshAcus: 4 },
+    ...overrides,
+  });
+
+  const createMockEntityView = (): AgentMonitorEntityView => ({
+    entity: {
+      id: "agententity_01hzx3entity1",
+      name: "Acme Corp",
+      domain: "acme.com",
+    },
+    contents: {
+      agentfield_01hzx3field1: {
+        value: "Jane Doe",
+        sourceUrls: ["https://acme.com/about"],
+        updatedAt: "2026-01-08T00:00:00.000Z",
+      },
+    },
+  });
+
+  const createMockChange = (): AgentMonitorChange => ({
+    type: "content.upserted",
+    entity: { id: "agententity_01hzx3entity1", name: "Acme Corp" },
+    field: { id: "agentfield_01hzx3field2", name: "funding" },
+    content: {
+      value: "Raised a $30M Series B",
+      sourceUrls: ["https://news.example.com/acme-series-b"],
+      updatedAt: "2026-01-08T00:00:00.000Z",
+    },
+    version: 3,
+    createdAt: "2026-01-08T00:00:01.000Z",
+  });
+
+  const snapshotBase = {
+    id: "agentsnap_01hzx3snap1",
+    object: "agent_monitor.snapshot" as const,
+    startTime: "2026-01-01T00:00:00.000Z",
+    endTime: "2026-01-08T00:00:00.000Z",
+    createdAt: "2026-01-09T00:00:00.000Z",
+    expiresAt: "2026-01-10T00:00:00.000Z",
+  };
+
+  const runningSnapshot: AgentMonitorSnapshot = {
+    ...snapshotBase,
+    status: "running",
+  };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    exa = new Exa("test-api-key", "https://api.exa.ai");
+  });
+
+  describe("Monitor Operations", () => {
+    it("should create an Agent Monitor", async () => {
+      const mockResponse = createMockMonitor({ status: "creating" });
+
+      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const createParams: CreateAgentMonitorParams = {
+        cadence: "7d",
+        entities: [
+          { name: "Acme Corp", domain: "acme.com" },
+          {
+            name: "Globex",
+            domain: "globex.com",
+            description: "Industrial conglomerate",
+          },
+        ],
+        fields: [
+          { name: "ceo", description: "The company's current CEO" },
+          {
+            name: "funding",
+            description: "New funding rounds",
+            type: "dynamic",
+          },
+        ],
+      };
+
+      const result = await exa.agent.monitors.create(createParams);
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "",
+        "POST",
+        createParams,
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(mockResponse);
+      expect(result.status).toBe("creating");
+    });
+
+    it("should send the Idempotency-Key header when creating with idempotencyKey", async () => {
+      const mockResponse = createMockMonitor({ status: "creating" });
+
+      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const createParams: CreateAgentMonitorParams = {
+        cadence: "12h",
+        entities: [{ name: "Acme Corp", domain: "acme.com" }],
+        fields: [{ name: "ceo", description: "The company's current CEO" }],
+      };
+
+      await exa.agent.monitors.create(createParams, {
+        idempotencyKey: "my-key-1",
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "",
+        "POST",
+        createParams,
+        undefined,
+        {
+          "Idempotency-Key": "my-key-1",
+        }
+      );
+    });
+
+    it("should get an Agent Monitor by ID", async () => {
+      const mockResponse = createMockMonitor();
+
+      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.get("agentmon_01hzx3example");
+
+      expect(requestSpy).toHaveBeenCalledWith("/agentmon_01hzx3example", "GET");
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("should list Agent Monitors with pagination params", async () => {
+      const mockResponse: ListAgentMonitorsResponse = {
+        object: "list",
+        data: [createMockMonitor()],
+        hasMore: false,
+        nextCursor: null,
+      };
+
+      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.list({
+        cursor: "agentmon_01hzxcursor",
+        limit: 10,
+      });
+
+      expect(requestSpy).toHaveBeenCalledWith("", "GET", undefined, {
+        cursor: "agentmon_01hzxcursor",
+        limit: 10,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("should iterate through all Agent Monitors with listAll", async () => {
+      const firstPage: ListAgentMonitorsResponse = {
+        object: "list",
+        data: [createMockMonitor({ id: "agentmon_1" })],
+        hasMore: true,
+        nextCursor: "agentmon_1",
+      };
+      const secondPage: ListAgentMonitorsResponse = {
+        object: "list",
+        data: [createMockMonitor({ id: "agentmon_2" })],
+        hasMore: false,
+        nextCursor: null,
+      };
+
+      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      const monitors = await exa.agent.monitors.getAll();
+
+      expect(monitors.map((monitor) => monitor.id)).toEqual([
+        "agentmon_1",
+        "agentmon_2",
+      ]);
+      expect(requestSpy).toHaveBeenCalledTimes(2);
+      expect(requestSpy).toHaveBeenLastCalledWith("", "GET", undefined, {
+        cursor: "agentmon_1",
+      });
+    });
+
+    it("should delete an Agent Monitor", async () => {
+      const mockResponse: DeletedAgentMonitor = {
+        id: "agentmon_01hzx3example",
+        object: "agent_monitor.deleted",
+        deleted: true,
+      };
+
+      const monitorsClient = getProtectedClient(exa.agent.monitors);
+      const requestSpy = vi
+        .spyOn(monitorsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.delete("agentmon_01hzx3example");
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/agentmon_01hzx3example",
+        "DELETE"
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe("Entity Operations", () => {
+    it("should add entities to a monitor", async () => {
+      const mockResponse = createMockMonitor({ entityCount: 3 });
+
+      const entitiesClient = getProtectedClient(exa.agent.monitors.entities);
+      const requestSpy = vi
+        .spyOn(entitiesClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const params = {
+        entities: [{ name: "Initech", domain: "initech.com" }],
+      };
+      const result = await exa.agent.monitors.entities.add(
+        "agentmon_01hzx3example",
+        params
+      );
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/agentmon_01hzx3example/entities",
+        "POST",
+        params
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("should list a monitor's entities with cursor, limit, and since", async () => {
+      const mockResponse: ListAgentMonitorEntitiesResponse = {
+        object: "list",
+        data: [createMockEntityView()],
+        hasMore: false,
+        nextCursor: null,
+        version: 3,
+      };
+
+      const entitiesClient = getProtectedClient(exa.agent.monitors.entities);
+      const requestSpy = vi
+        .spyOn(entitiesClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.entities.list(
+        "agentmon_01hzx3example",
+        { cursor: "abc", limit: 50, since: "2026-01-07T00:00:00.000Z" }
+      );
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/agentmon_01hzx3example/entities",
+        "GET",
+        undefined,
+        { cursor: "abc", limit: 50, since: "2026-01-07T00:00:00.000Z" }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("should iterate through all entities with listAll", async () => {
+      const firstPage: ListAgentMonitorEntitiesResponse = {
+        object: "list",
+        data: [createMockEntityView()],
+        hasMore: true,
+        nextCursor: "cursor-2",
+        version: 3,
+      };
+      const secondPage: ListAgentMonitorEntitiesResponse = {
+        object: "list",
+        data: [createMockEntityView()],
+        hasMore: false,
+        nextCursor: null,
+        version: 3,
+      };
+
+      const entitiesClient = getProtectedClient(exa.agent.monitors.entities);
+      const requestSpy = vi
+        .spyOn(entitiesClient, "request")
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      const entities = await exa.agent.monitors.entities.getAll(
+        "agentmon_01hzx3example"
+      );
+
+      expect(entities).toHaveLength(2);
+      expect(requestSpy).toHaveBeenCalledTimes(2);
+      expect(requestSpy).toHaveBeenLastCalledWith(
+        "/agentmon_01hzx3example/entities",
+        "GET",
+        undefined,
+        { cursor: "cursor-2" }
+      );
+    });
+  });
+
+  describe("Change Feed Operations", () => {
+    it("should list a monitor's changes", async () => {
+      const mockResponse: ListAgentMonitorChangesResponse = {
+        object: "list",
+        data: [createMockChange()],
+        hasMore: false,
+        nextCursor: "change-cursor-1",
+        version: 3,
+      };
+
+      const changesClient = getProtectedClient(exa.agent.monitors.changes);
+      const requestSpy = vi
+        .spyOn(changesClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.changes.list(
+        "agentmon_01hzx3example",
+        { since: "2026-01-07T00:00:00.000Z" }
+      );
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/agentmon_01hzx3example/changes",
+        "GET",
+        undefined,
+        { since: "2026-01-07T00:00:00.000Z" }
+      );
+      expect(result).toEqual(mockResponse);
+      expect(result.data[0].createdAt).toBe("2026-01-08T00:00:01.000Z");
+    });
+
+    it("should resume the change feed from a cursor with listAll", async () => {
+      const firstPage: ListAgentMonitorChangesResponse = {
+        object: "list",
+        data: [createMockChange()],
+        hasMore: true,
+        nextCursor: "change-cursor-2",
+        version: 3,
+      };
+      const secondPage: ListAgentMonitorChangesResponse = {
+        object: "list",
+        data: [createMockChange()],
+        hasMore: false,
+        nextCursor: "change-cursor-3",
+        version: 3,
+      };
+
+      const changesClient = getProtectedClient(exa.agent.monitors.changes);
+      const requestSpy = vi
+        .spyOn(changesClient, "request")
+        .mockResolvedValueOnce(firstPage)
+        .mockResolvedValueOnce(secondPage);
+
+      const changes = await exa.agent.monitors.changes.getAll(
+        "agentmon_01hzx3example",
+        { cursor: "change-cursor-1" }
+      );
+
+      expect(changes).toHaveLength(2);
+      expect(requestSpy).toHaveBeenNthCalledWith(
+        1,
+        "/agentmon_01hzx3example/changes",
+        "GET",
+        undefined,
+        { cursor: "change-cursor-1" }
+      );
+      expect(requestSpy).toHaveBeenNthCalledWith(
+        2,
+        "/agentmon_01hzx3example/changes",
+        "GET",
+        undefined,
+        { cursor: "change-cursor-2" }
+      );
+    });
+  });
+
+  describe("Snapshot Operations", () => {
+    const snapshotParams: CreateAgentMonitorSnapshotParams = {
+      entities: [{ name: "Acme Corp", domain: "acme.com" }],
+      fields: [
+        { name: "funding", description: "New funding rounds", type: "dynamic" },
+      ],
+      startDate: "2026-01-01",
+      endDate: "2026-01-08",
+      endHour: 12,
+    };
+
+    it("should start a snapshot job", async () => {
+      const mockResponse = runningSnapshot;
+
+      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const requestSpy = vi
+        .spyOn(snapshotsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.snapshots.create(snapshotParams);
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/snapshot",
+        "POST",
+        snapshotParams
+      );
+      expect(result.status).toBe("running");
+    });
+
+    it("should poll a snapshot job by ID", async () => {
+      const mockResponse: AgentMonitorSnapshot = {
+        ...snapshotBase,
+        status: "completed",
+        data: [
+          {
+            name: "Acme Corp",
+            fields: { funding: "Raised a $30M Series B" },
+            sourceUrls: ["https://news.example.com/acme-series-b"],
+          },
+        ],
+        warnings: [],
+      };
+
+      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      const requestSpy = vi
+        .spyOn(snapshotsClient, "request")
+        .mockResolvedValueOnce(mockResponse);
+
+      const result = await exa.agent.monitors.snapshots.get(
+        "agentsnap_01hzx3snap1"
+      );
+
+      expect(requestSpy).toHaveBeenCalledWith(
+        "/snapshot/agentsnap_01hzx3snap1",
+        "GET"
+      );
+      expect(result.status).toBe("completed");
+      if (result.status === "completed") {
+        expect(result.data[0].fields.funding).toBe("Raised a $30M Series B");
+      }
+    });
+
+    it("should createAndWait until the snapshot completes", async () => {
+      const completed: AgentMonitorSnapshot = {
+        ...snapshotBase,
+        status: "completed",
+        data: [],
+      };
+
+      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      vi.spyOn(snapshotsClient, "request")
+        .mockResolvedValueOnce(runningSnapshot)
+        .mockResolvedValueOnce(runningSnapshot)
+        .mockResolvedValueOnce(completed);
+
+      const result = await exa.agent.monitors.snapshots.createAndWait(
+        snapshotParams,
+        { pollInterval: 1 }
+      );
+
+      expect(result.status).toBe("completed");
+    });
+
+    it("should throw AgentMonitorSnapshotFailedError when the snapshot fails", async () => {
+      const failed: AgentMonitorSnapshot = {
+        ...snapshotBase,
+        status: "failed",
+        error: "newsfeed unavailable",
+      };
+
+      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      vi.spyOn(snapshotsClient, "request")
+        .mockResolvedValueOnce(runningSnapshot)
+        .mockResolvedValueOnce(failed);
+
+      await expect(
+        exa.agent.monitors.snapshots.createAndWait(snapshotParams, {
+          pollInterval: 1,
+        })
+      ).rejects.toThrow(AgentMonitorSnapshotFailedError);
+    });
+
+    it("should time out pollUntilFinished when the snapshot never finishes", async () => {
+      const snapshotsClient = getProtectedClient(exa.agent.monitors.snapshots);
+      vi.spyOn(snapshotsClient, "request").mockResolvedValue(runningSnapshot);
+
+      await expect(
+        exa.agent.monitors.snapshots.pollUntilFinished(
+          "agentsnap_01hzx3snap1",
+          {
+            pollInterval: 1,
+            timeoutMs: 5,
+          }
+        )
+      ).rejects.toThrow(/Polling timeout/);
+    });
+  });
+});

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -32,12 +32,14 @@ describe("Agent Monitors API", () => {
         id: "agentfield_01hzx3field1",
         name: "ceo",
         description: "The company's current CEO",
+        mode: "static",
         type: "static",
       },
       {
         id: "agentfield_01hzx3field2",
         name: "funding",
         description: "New funding rounds",
+        mode: "dynamic",
         type: "dynamic",
       },
     ],
@@ -163,11 +165,11 @@ describe("Agent Monitors API", () => {
           },
         ],
         fields: [
-          { name: "ceo", description: "The company's current CEO" },
+          { name: "funding", description: "New funding rounds" },
           {
-            name: "funding",
-            description: "New funding rounds",
-            type: "dynamic",
+            name: "ceo",
+            description: "The company's current CEO",
+            mode: "static",
           },
         ],
       };
@@ -569,7 +571,7 @@ describe("Agent Monitors API", () => {
     const snapshotParams: CreateAgentMonitorSnapshotParams = {
       entities: [{ name: "Acme Corp", domain: "acme.com" }],
       fields: [
-        { name: "funding", description: "New funding rounds", type: "dynamic" },
+        { name: "funding", description: "New funding rounds", mode: "dynamic" },
       ],
       startDate: "2026-01-01",
       endDate: "2026-01-08",

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -8,6 +8,12 @@ import {
   AgentRunsClient,
   AgentRunEventsClient,
 } from "../../src/agent/client";
+import {
+  AgentMonitorChangesClient,
+  AgentMonitorEntitiesClient,
+  AgentMonitorSnapshotsClient,
+  AgentMonitorsClient,
+} from "../../src/agent/monitors/client";
 import { WebsetsBaseClient } from "../../src/websets/base";
 import { WebsetsClient } from "../../src/websets/client";
 import { WebsetEnrichmentsClient } from "../../src/websets/enrichments";
@@ -47,7 +53,11 @@ export function getProtectedClient<
     | AgentBetaRunsClient
     | AgentBetaRunEventsClient
     | AgentRunsClient
-    | AgentRunEventsClient,
+    | AgentRunEventsClient
+    | AgentMonitorsClient
+    | AgentMonitorEntitiesClient
+    | AgentMonitorChangesClient
+    | AgentMonitorSnapshotsClient,
 >(client: T): WithProtectedAccess<T> {
   return client as WithProtectedAccess<T>;
 }
@@ -71,6 +81,10 @@ export function getProtectedClientInstance(
     | AgentBetaRunEventsClient
     | AgentRunsClient
     | AgentRunEventsClient
+    | AgentMonitorsClient
+    | AgentMonitorEntitiesClient
+    | AgentMonitorChangesClient
+    | AgentMonitorSnapshotsClient
 ) {
   return client;
 }

--- a/test/unit/request-error-handling.test.ts
+++ b/test/unit/request-error-handling.test.ts
@@ -35,6 +35,37 @@ function handle(url: string): {
           message: "Invalid query",
         }),
       };
+    case "/agent-error":
+      return {
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            type: "CONFLICT",
+            code: "IDEMPOTENCY_KEY_CONFLICT",
+            message: "Idempotency-Key was already used for a different request",
+            detail: "the key is bound to the body it created",
+          },
+          requestId: "req_e2e123",
+        }),
+      };
+    case "/agent-error-no-message":
+      return {
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { type: "NOT_FOUND", code: "MONITOR_NOT_FOUND" },
+        }),
+      };
+    case "/legacy-error-with-request-id":
+      return {
+        status: 429,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: "Rate limited",
+          requestId: "req_legacy1",
+        }),
+      };
     case "/empty-ok":
       return { status: 200, contentType: "application/json", body: "" };
     default:
@@ -88,11 +119,56 @@ describe("Exa.request non-JSON response handling", () => {
   });
 
   it("still surfaces structured JSON API errors unchanged", async () => {
-    const error = await exa.request("/json-error", "POST").catch((e) => e);
+    const error = (await exa
+      .request("/json-error", "POST")
+      .catch((e) => e)) as ExaError;
     expect(error).toBeInstanceOf(ExaError);
     expect(error.statusCode).toBe(400);
     expect(error.message).toBe("Bad Request. Invalid query");
     expect(error.path).toBe("/json-error");
+    expect(error.type).toBeUndefined();
+    expect(error.code).toBeUndefined();
+  });
+
+  it("unwraps a structured error envelope instead of '[object Object]'", async () => {
+    const error = (await exa
+      .request("/agent-error", "POST")
+      .catch((e) => e)) as ExaError;
+    expect(error).toBeInstanceOf(ExaError);
+    expect(error.statusCode).toBe(409);
+    expect(error.message).toBe(
+      "Idempotency-Key was already used for a different request"
+    );
+    expect(error.message).not.toContain("[object Object]");
+    expect(error.type).toBe("CONFLICT");
+    expect(error.code).toBe("IDEMPOTENCY_KEY_CONFLICT");
+    expect(error.detail).toBe("the key is bound to the body it created");
+    expect(error.requestId).toBe("req_e2e123");
+    expect(error.path).toBe("/agent-error");
+  });
+
+  it("falls back to 'Unknown error' when a structured envelope has no message", async () => {
+    const error = (await exa
+      .request("/agent-error-no-message", "GET")
+      .catch((e) => e)) as ExaError;
+    expect(error).toBeInstanceOf(ExaError);
+    expect(error.statusCode).toBe(404);
+    expect(error.message).toBe("Unknown error");
+    expect(error.type).toBe("NOT_FOUND");
+    expect(error.code).toBe("MONITOR_NOT_FOUND");
+    expect(error.requestId).toBeUndefined();
+  });
+
+  it("keeps the legacy string envelope intact and carries a top-level requestId", async () => {
+    const error = (await exa
+      .request("/legacy-error-with-request-id", "GET")
+      .catch((e) => e)) as ExaError;
+    expect(error).toBeInstanceOf(ExaError);
+    expect(error.statusCode).toBe(429);
+    expect(error.message).toBe("Rate limited");
+    expect(error.type).toBeUndefined();
+    expect(error.code).toBeUndefined();
+    expect(error.requestId).toBe("req_legacy1");
   });
 
   it("returns parsed JSON for a normal successful response", async () => {


### PR DESCRIPTION
## Summary

Adds SDK support for the **Agent Monitors API** (`/agent/monitors`), a beta Agent product for keeping a table of entities and fields fresh on a cadence.

The client lives under the **beta** Agent namespace at `exa.beta.agent.monitors.*`.

Every monitors request requires `betas` to include `AGENT_MONITORS_BETA_HEADER` (`agent-monitors-2026-08-04`). This is sent as the `Exa-Beta` header through the shared `headersForBetas` helper in `src/agent/betas.ts`. Omitting it throws an `ExaError` with status 400.

Fields are **dynamic by default**, meaning they're refreshed from news on every cadence. Set `mode: "static"` to answer a field once from the live web and never refresh it. The deprecated `type` spelling is still accepted as an alias, but a field can't specify both. Responses echo both `mode` and `type`.

## Coverage

| Endpoint                            | SDK                                                                   |
| ----------------------------------- | --------------------------------------------------------------------- |
| `POST /agent/monitors`              | `exa.beta.agent.monitors.create({ ..., betas }, { idempotencyKey? })` |
| `GET /agent/monitors`               | `list` / `listAll` / `getAll` (auto-pagination)                       |
| `GET /agent/monitors/:id`           | `get`                                                                 |
| `DELETE /agent/monitors/:id`        | `delete`                                                              |
| `POST /agent/monitors/:id/entities` | `entities.add`                                                        |
| `GET /agent/monitors/:id/entities`  | `entities.list` / `listAll` / `getAll` (cursor + `since`)             |
| `GET /agent/monitors/:id/changes`   | `changes.list` / `listAll` / `getAll` (cursor + `since`)              |
| `POST /agent/monitors/snapshot`     | `snapshots.create`                                                    |
| `GET /agent/monitors/snapshot/:id`  | `snapshots.get` / `pollUntilFinished` / `createAndWait`               |

## Usage

```ts
import { AGENT_MONITORS_BETA_HEADER } from "exa-js";

const betas = [AGENT_MONITORS_BETA_HEADER];

const monitor = await exa.beta.agent.monitors.create(
  {
    betas,
    cadence: "7d",
    entities: [{ name: "Acme Corp", domain: "acme.com" }],
    fields: [
      { name: "funding", description: "New funding rounds" }, // dynamic by default
      { name: "ceo", description: "The company's current CEO", mode: "static" },
    ],
  },
  { idempotencyKey: "my-monitor-1" }
);

for await (const { entity, contents } of exa.beta.agent.monitors.entities.listAll(
  monitor.id,
  { betas }
)) {
  console.log(entity.name, contents);
}

const snapshot = await exa.beta.agent.monitors.snapshots.createAndWait({
  betas,
  entities: [{ name: "Acme Corp", domain: "acme.com" }],
  fields: [{ name: "funding", description: "New funding rounds" }],
  startDate: "2026-01-01",
  endDate: "2026-01-08",
});

console.log(snapshot.data);
```

## Notes

* Import the beta identifier from `exa-js` as `AGENT_MONITORS_BETA_HEADER`.
* `create` sends `Idempotency-Key` when `idempotencyKey` is provided.
* `snapshots.createAndWait` throws `AgentMonitorSnapshotFailedError` if the snapshot job fails, mirroring `AgentRunFailedError`.