### PR TITLE
agent monitors: rename field `type` to `mode`, fix dynamic-by-default docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ const monitor = await exa.beta.agent.monitors.create(
       { name: "Globex", domain: "globex.com" },
     ],
     fields: [
-      { name: "ceo", description: "The company's current CEO" }, // static by default
-      { name: "funding", description: "New funding rounds", type: "dynamic" },
+      { name: "funding", description: "New funding rounds" }, // dynamic by default
+      { name: "ceo", description: "The company's current CEO", mode: "static" },
     ],
   },
   { idempotencyKey: "my-monitor-1" } // safe retries: same key returns the same monitor
@@ -221,7 +221,7 @@ const snapshot = await exa.beta.agent.monitors.snapshots.createAndWait({
   betas,
   entities: [{ name: "Acme Corp", domain: "acme.com" }],
   fields: [
-    { name: "funding", description: "New funding rounds", type: "dynamic" },
+    { name: "funding", description: "New funding rounds" }, // dynamic by default
   ],
   startDate: "2026-01-01",
   endDate: "2026-01-08",

--- a/src/agent/monitors/types.ts
+++ b/src/agent/monitors/types.ts
@@ -19,18 +19,23 @@ export type AgentMonitorStatus =
   | "pending_first_refresh"
   | "active";
 
-export type AgentMonitorFieldType = "static" | "dynamic";
+export type AgentMonitorFieldMode = "static" | "dynamic";
+
+/** @deprecated Renamed to {@link AgentMonitorFieldMode}. */
+export type AgentMonitorFieldType = AgentMonitorFieldMode;
 
 /**
- * A field the monitor keeps fresh for every entity. Fields are static
- * (answered once over the live web) unless declared `type: "dynamic"`
- * (tracked from news on every refresh).
+ * A field the monitor keeps fresh for every entity. Fields are dynamic
+ * (tracked from news on every refresh) unless declared `mode: "static"`
+ * (answered once over the live web).
  */
 export interface AgentMonitorField {
   id: string;
   name: string;
   description: string;
-  type: AgentMonitorFieldType;
+  mode: AgentMonitorFieldMode;
+  /** @deprecated Renamed to `mode`; echoes the same value until removed. */
+  type: AgentMonitorFieldMode;
 }
 
 /** An entity tracked by the monitor. */
@@ -138,11 +143,13 @@ export interface CreateAgentMonitorEntityParams {
   description?: string;
 }
 
-/** A field to keep fresh. Static (the default) unless declared `type: "dynamic"`. */
+/** A field to keep fresh. Dynamic (the default) unless declared `mode: "static"`. */
 export interface CreateAgentMonitorFieldParams {
   name: string;
   description: string;
-  type?: AgentMonitorFieldType;
+  mode?: AgentMonitorFieldMode;
+  /** @deprecated Renamed to `mode`; declare one spelling, not both. */
+  type?: AgentMonitorFieldMode;
 }
 
 export interface CreateAgentMonitorParams {

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -32,12 +32,14 @@ describe("Agent Monitors API", () => {
         id: "agentfield_01hzx3field1",
         name: "ceo",
         description: "The company's current CEO",
+        mode: "static",
         type: "static",
       },
       {
         id: "agentfield_01hzx3field2",
         name: "funding",
         description: "New funding rounds",
+        mode: "dynamic",
         type: "dynamic",
       },
     ],
@@ -163,11 +165,11 @@ describe("Agent Monitors API", () => {
           },
         ],
         fields: [
-          { name: "ceo", description: "The company's current CEO" },
+          { name: "funding", description: "New funding rounds" },
           {
-            name: "funding",
-            description: "New funding rounds",
-            type: "dynamic",
+            name: "ceo",
+            description: "The company's current CEO",
+            mode: "static",
           },
         ],
       };
@@ -569,7 +571,7 @@ describe("Agent Monitors API", () => {
     const snapshotParams: CreateAgentMonitorSnapshotParams = {
       entities: [{ name: "Acme Corp", domain: "acme.com" }],
       fields: [
-        { name: "funding", description: "New funding rounds", type: "dynamic" },
+        { name: "funding", description: "New funding rounds", mode: "dynamic" },
       ],
       startDate: "2026-01-01",
       endDate: "2026-01-08",


### PR DESCRIPTION
Stacked on #205 (targets its branch, so it shows only this delta).

Follows [exa-labs/monorepo#126125](https://github.com/exa-labs/monorepo/pull/126125), which renames the Agent Monitors public field argument `type` to `mode: "static" | "dynamic"` (`type` stays accepted server-side as a deprecated alias; a field may declare one spelling, not both).

- `AgentMonitorFieldMode` replaces `AgentMonitorFieldType` (kept as a deprecated alias type).
- `CreateAgentMonitorFieldParams` gains `mode?`; `type?` stays, marked deprecated.
- `AgentMonitorField` (response shape) carries both `mode` and deprecated `type` — the server echoes both with the same value.
- Fixes the README and type docs that taught **static by default**: the server defaults omitted fields to **dynamic** (this was already flagged as a discrepancy in monorepo#126111).
- Examples and tests updated to the `mode` spelling; fixtures echo both keys like real responses.

Verified: `vitest run test/unit/agent-monitors.test.ts` — 21/21 pass; `tsc --noEmit` shows the same 59 pre-existing errors (unrelated websets tests) before and after, none from this change.

**Merge order**: after #205 (base) and not before monorepo#126125 is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)