### PR TITLE
agent monitors: field `type` is the cell value type

### DIFF
--- a/src/agent/monitors/types.ts
+++ b/src/agent/monitors/types.ts
@@ -21,8 +21,15 @@ export type AgentMonitorStatus =
 
 export type AgentMonitorFieldMode = "static" | "dynamic";
 
-/** @deprecated Renamed to {@link AgentMonitorFieldMode}. */
-export type AgentMonitorFieldType = AgentMonitorFieldMode;
+/** The type of a field's cell values. */
+export type AgentMonitorFieldValueType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "date"
+  | "url"
+  | "email"
+  | "phone";
 
 /**
  * A field the monitor keeps fresh for every entity. Fields are dynamic
@@ -33,9 +40,10 @@ export interface AgentMonitorField {
   id: string;
   name: string;
   description: string;
+  /** @deprecated The static/dynamic knob is becoming internal-only. */
   mode: AgentMonitorFieldMode;
-  /** @deprecated Renamed to `mode`; echoes the same value until removed. */
-  type: AgentMonitorFieldMode;
+  /** The type of the field's cell values. */
+  type: AgentMonitorFieldValueType;
 }
 
 /** An entity tracked by the monitor. */
@@ -46,10 +54,18 @@ export interface AgentMonitorEntity {
   canonicalEntityId?: string;
 }
 
+/** One grounding citation for a cell value; the Agent API's citation shape. */
+export interface AgentMonitorCitation {
+  url: string;
+  title?: string;
+  note?: string;
+}
+
 /** One cell value: a field's current content for an entity. */
 export interface AgentMonitorContent {
   value: unknown;
-  sourceUrls?: string[];
+  /** Grounding for the value, in the Agent API's citation shape. */
+  citations?: AgentMonitorCitation[];
   updatedAt: string;
 }
 
@@ -147,9 +163,16 @@ export interface CreateAgentMonitorEntityParams {
 export interface CreateAgentMonitorFieldParams {
   name: string;
   description: string;
+  /**
+   * The type of the field's cell values; defaults to `"string"`. Cell values
+   * are normalized to the declared type best-effort on write, never rejected
+   * — but declaring an unsupported type (e.g. `"object"`) is a 400.
+   * `"static"`/`"dynamic"` are accepted as deprecated aliases of `mode`;
+   * declaring both spellings is a 400.
+   */
+  type?: AgentMonitorFieldValueType | AgentMonitorFieldMode;
+  /** @deprecated The static/dynamic knob is becoming internal-only. */
   mode?: AgentMonitorFieldMode;
-  /** @deprecated Renamed to `mode`; declare one spelling, not both. */
-  type?: AgentMonitorFieldMode;
 }
 
 export interface CreateAgentMonitorParams {

--- a/test/unit/agent-monitors.test.ts
+++ b/test/unit/agent-monitors.test.ts
@@ -33,14 +33,14 @@ describe("Agent Monitors API", () => {
         name: "ceo",
         description: "The company's current CEO",
         mode: "static",
-        type: "static",
+        type: "string",
       },
       {
         id: "agentfield_01hzx3field2",
         name: "funding",
         description: "New funding rounds",
         mode: "dynamic",
-        type: "dynamic",
+        type: "string",
       },
     ],
     entityCount: 2,
@@ -62,7 +62,7 @@ describe("Agent Monitors API", () => {
     contents: {
       agentfield_01hzx3field1: {
         value: "Jane Doe",
-        sourceUrls: ["https://acme.com/about"],
+        citations: [{ url: "https://acme.com/about" }],
         updatedAt: "2026-01-08T00:00:00.000Z",
       },
     },
@@ -74,7 +74,7 @@ describe("Agent Monitors API", () => {
     field: { id: "agentfield_01hzx3field2", name: "funding" },
     content: {
       value: "Raised a $30M Series B",
-      sourceUrls: ["https://news.example.com/acme-series-b"],
+      citations: [{ url: "https://news.example.com/acme-series-b" }],
       updatedAt: "2026-01-08T00:00:00.000Z",
     },
     version: 3,
@@ -170,6 +170,11 @@ describe("Agent Monitors API", () => {
             name: "ceo",
             description: "The company's current CEO",
             mode: "static",
+          },
+          {
+            name: "headcount",
+            description: "Current number of employees",
+            type: "number",
           },
         ],
       };
@@ -571,7 +576,7 @@ describe("Agent Monitors API", () => {
     const snapshotParams: CreateAgentMonitorSnapshotParams = {
       entities: [{ name: "Acme Corp", domain: "acme.com" }],
       fields: [
-        { name: "funding", description: "New funding rounds", mode: "dynamic" },
+        { name: "funding", description: "New funding rounds", type: "dynamic" },
       ],
       startDate: "2026-01-01",
       endDate: "2026-01-08",


### PR DESCRIPTION
Monitor field `type` now means the cell value type, not the static/dynamic knob, and cell grounding is `citations` in the Agent API shape. Matches the server contracts in exa-labs/monorepo#126125 and exa-labs/monorepo#126298.

```diff
 interface AgentMonitorField {
-  mode: "static" | "dynamic";
-  type: "static" | "dynamic"; // duplicate echo of mode
+  mode: "static" | "dynamic"; // @deprecated
+  type: "string" | "number" | "boolean" | "date" | "url" | "email" | "phone";
 }

 interface AgentMonitorContent {
   value: unknown;
-  sourceUrls?: string[];
+  citations?: AgentMonitorCitation[]; // { url, title?, note? } — Agent API shape
   updatedAt: string;
 }
```

- New exports `AgentMonitorFieldValueType` and `AgentMonitorCitation`; the deprecated `AgentMonitorFieldType` alias is removed. Agent Monitors have not gone public — the surface is beta-gated and used internally only — so these re-typings affect no external consumers and ship as a regular `feat:` minor.
- Create/snapshot params: `type` takes a value type — defaults to `"string"`; cell values are normalized best-effort on write, never rejected, but declaring an unsupported type (e.g. `"object"`) is a 400. Legacy `type: "static" | "dynamic"` still compiles as a deprecated alias of `mode`; declaring both spellings is a 400.
- Responses always carry both field keys: the server dual-emits `mode` and `type` for every field. Snapshots keep bare `sourceUrls` (deliberately raw).

⚠️ Merge/release only after exa-labs/monorepo#126125 and exa-labs/monorepo#126298 deploy (both merged 2026-08-14; docs merged in exa-labs/monorepo#126111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
