### PR TITLE
feat: support agent max duration for max effort

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ const maxRun = await exa.beta.agent.runs.create({
   query:
     "Find all companies building browser automation tools in the United States.",
   effort: "max",
-  budget: { maxCostDollars: 10 },
+  budget: { maxCostDollars: 10, maxDurationSeconds: 600 },
   betas: [AGENT_MAX_EFFORT_BETA],
 });
 ```

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -30,6 +30,8 @@ export type AgentRunStatus =
 export type AgentStopReason =
   | "schema_satisfied"
   | "budget_reached"
+  | "time_limit_reached"
+  | "timeout_partial"
   | "error"
   | "cancelled";
 
@@ -44,7 +46,10 @@ export type AgentEffort =
   | "auto"
   | "max";
 
-/** Per-run spend ceiling for the metered `auto` and `max` efforts. */
+/**
+ * Per-run budget ceilings for the metered efforts: the cost ceiling applies
+ * to `auto` and `max`; the duration ceiling applies to `max` only.
+ */
 export interface AgentBudget {
   /**
    * Maximum spend for the run in US dollars.
@@ -52,6 +57,12 @@ export interface AgentBudget {
    * allowed range and applies defaults when omitted.
    */
   maxCostDollars?: number;
+  /**
+   * Best-effort maximum duration for the run in seconds.
+   * Only accepted by the API for `max`; the server validates the allowed
+   * range and may take a little additional time to finish gracefully.
+   */
+  maxDurationSeconds?: number;
 }
 
 /**

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -61,6 +61,9 @@ export interface AgentBudget {
    * Best-effort maximum duration for the run in seconds.
    * Only accepted by the API for `max`; the server validates the allowed
    * range and may take a little additional time to finish gracefully.
+   * Runs that hit the limit stop with `stopReason: "time_limit_reached"`
+   * (or `"timeout_partial"` if the graceful wrap-up could not finish) and
+   * return partial output.
    */
   maxDurationSeconds?: number;
 }

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -203,7 +203,7 @@ describe("Agent API", () => {
       betas: [AGENT_MAX_EFFORT_BETA],
       query: "Find recent funding rounds.",
       effort: "max",
-      budget: { maxCostDollars: 10 },
+      budget: { maxCostDollars: 10, maxDurationSeconds: 600 },
     });
 
     expect(requestSpy).toHaveBeenCalledWith(
@@ -212,7 +212,7 @@ describe("Agent API", () => {
       {
         query: "Find recent funding rounds.",
         effort: "max",
-        budget: { maxCostDollars: 10 },
+        budget: { maxCostDollars: 10, maxDurationSeconds: 600 },
       },
       undefined,
       { "Exa-Beta": AGENT_MAX_EFFORT_BETA }


### PR DESCRIPTION
Adds support for the agent max duration budget:

- `AgentBudget` gains an optional `maxDurationSeconds` field, a best-effort maximum run duration in seconds. Only accepted by the API for `max` effort; the server validates the allowed range and may take a little additional time to finish gracefully.
- `AgentStopReason` gains `time_limit_reached` and `timeout_partial`.

Unit tests updated to exercise the new budget field end-to-end (160 passed). Verified live against production: range/type/effort-gating validation, budget echo and persistence, and a real run hitting the soft deadline with `stopReason=time_limit_reached`.