### PR TITLE
fix(research): release reader lock in streaming get() path

### DIFF
--- a/src/research/client.ts
+++ b/src/research/client.ts
@@ -112,26 +112,37 @@ export class ResearchClient extends ResearchBaseClient {
         }
 
         async function* streamEvents() {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-            buffer += decoder.decode(value, { stream: true });
+          let doneReading = false;
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) {
+                doneReading = true;
+                break;
+              }
+              buffer += decoder.decode(value, { stream: true });
 
-            let parts = buffer.split("\n\n");
-            buffer = parts.pop() ?? "";
+              let parts = buffer.split("\n\n");
+              buffer = parts.pop() ?? "";
 
-            for (const part of parts) {
-              const processed = processPart(part);
+              for (const part of parts) {
+                const processed = processPart(part);
+                if (processed) {
+                  yield processed;
+                }
+              }
+            }
+            if (buffer.trim()) {
+              const processed = processPart(buffer.trim());
               if (processed) {
                 yield processed;
               }
             }
-          }
-          if (buffer.trim()) {
-            const processed = processPart(buffer.trim());
-            if (processed) {
-              yield processed;
+          } finally {
+            if (!doneReading) {
+              await reader.cancel();
             }
+            reader.releaseLock();
           }
         }
 


### PR DESCRIPTION
When you call `exa.research.get(id, { stream: true })`, the SDK opens a reader on the SSE response body. Every other streaming path in the codebase (`streamChatCompletions`, `parseSSEStream`, `streamAgentEvents`) wraps its read loop in `try/finally` and calls `reader.releaseLock()` when it's done. The research streaming path doesn't. The lock is held until the reader gets garbage collected, which means the underlying connection and its buffers stick around longer than they should.

This isn't something you'd notice on a single call, but if you're making repeated streaming research requests, say in a worker that processes jobs, the connections pile up. In HTTP/1.1 keep-alive environments, that's a real leak.

The fix wraps the `streamEvents()` generator body in `try/finally`, matching the exact pattern `streamAgentEvents` in `src/agent/client.ts` already uses: track whether the stream was fully consumed, cancel the reader if it wasn't, then always release the lock.

All 172 unit tests pass. No type errors introduced.