### PR TITLE
Add graceful Agent run stopping

### DIFF
--- a/src/agent/client.ts
+++ b/src/agent/client.ts
@@ -10,6 +10,7 @@ import { AgentBaseClient } from "./base";
 import { headersForBetas } from "./betas";
 import { AgentMonitorsClient } from "./monitors/client";
 import {
+  AGENT_MAX_EFFORT_BETA,
   AgentBetaOptions,
   AgentCreateOptions,
   AgentEvent,
@@ -519,6 +520,20 @@ export class AgentBetaRunsClient extends AgentRunsClient {
       undefined,
       undefined,
       headersForBetas(options?.betas)
+    );
+  }
+
+  /**
+   * Stop a running Agent run, completing it early with the results
+   * gathered so far. Only supported for `max` effort runs.
+   */
+  async stop(runId: string, options?: AgentBetaOptions): Promise<AgentRun> {
+    return this.request<AgentRun>(
+      `/${runId}/stop`,
+      "POST",
+      undefined,
+      undefined,
+      headersForBetas(options?.betas ?? [AGENT_MAX_EFFORT_BETA])
     );
   }
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -30,6 +30,7 @@ export type AgentRunStatus =
 export type AgentStopReason =
   | "schema_satisfied"
   | "budget_reached"
+  | "stopped"
   | "error"
   | "cancelled";
 

--- a/test/unit/agent.test.ts
+++ b/test/unit/agent.test.ts
@@ -78,6 +78,8 @@ describe("Agent API", () => {
   it("exposes Agent runs under the primary namespace", () => {
     expect(exa.agent.runs).toBeDefined();
     expect((exa.agent as any).run).toBeUndefined();
+    expect((exa.agent.runs as any).stop).toBeUndefined();
+    expect(exa.beta.agent.runs.stop).toBeDefined();
   });
 
   it("keeps the beta Agent namespace as a compatibility wrapper", () => {
@@ -104,6 +106,9 @@ describe("Agent API", () => {
       exa.beta.agent.runs.get("agent_run_123", {
         betas: [AGENT_BETA_HEADER],
       });
+      // @ts-expect-error stop is only available through exa.beta.agent.
+      exa.agent.runs.stop("agent_run_123");
+      exa.beta.agent.runs.stop("agent_run_123");
       exa.agent.runs.createAndWait({
         query: "Find companies.",
         // @ts-expect-error betas are only accepted through exa.beta.agent.
@@ -334,6 +339,23 @@ describe("Agent API", () => {
       undefined,
       undefined,
       undefined
+    );
+  });
+
+  it("stops max-effort runs through the beta namespace", async () => {
+    const runClient = getProtectedClient(exa.beta.agent.runs);
+    const requestSpy = vi
+      .spyOn(runClient, "request")
+      .mockResolvedValueOnce(createMockRun());
+
+    await exa.beta.agent.runs.stop("agent_run_123");
+
+    expect(requestSpy).toHaveBeenCalledWith(
+      "/agent_run_123/stop",
+      "POST",
+      undefined,
+      undefined,
+      { "Exa-Beta": AGENT_MAX_EFFORT_BETA }
     );
   });
 


### PR DESCRIPTION
Depends on #218.

Adds `beta.agent.runs.stop` for max-effort runs and supports the `stopped` stop reason.