### PR TITLE
fix(ci): approve esbuild build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
Approves `esbuild` install scripts so pnpm 11 can install dependencies in CI.