### PR TITLE
feat(helpers): get_contents tool helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ for await (const chunk of exa.streamAnswer("Explain quantum computing")) {
 }
 ```
 
-## Web Search tools
+## Web Search and Contents tools
 
 Use Exa as a `web_search` tool in an OpenAI or Anthropic loop. Call `webSearch()` with no arguments to get Exa's recommended settings for agentic search (`type: "auto"` and `contents: { highlights: true }`).
 
@@ -167,6 +167,19 @@ const response = await anthropic.messages.create({
   tools: [
     { type: "web_search_20250305", name: "web_search", max_uses: 5 },
     exa.anthropic.webSearch({ name: "exa_web_search" }),
+  ],
+});
+```
+
+`getContents()` is available in the same namespaces and lets the model read pages it already has URLs for. It takes a list of URLs and accepts every `exa.getContents` option:
+
+```ts
+const completion = await openai.chat.completions.create({
+  model: "gpt-5.6",
+  messages,
+  tools: [
+    exa.openai.webSearch(),
+    exa.openai.getContents({ summary: true, livecrawl: "preferred" }),
   ],
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { isZodSchema, zodToJsonSchema } from "./zod-utils";
 import { AnthropicTools } from "./tools/anthropic";
 import { OpenAITools } from "./tools/openai";
 import {
+  createGetContentsTool,
   createWebSearchTool,
   ToolRegistry,
   type ToolNamespace,
@@ -891,6 +892,8 @@ export class Exa {
     this.tools = {
       webSearch: (options) =>
         createWebSearchTool(this, this.toolRegistry, options),
+      getContents: (options) =>
+        createGetContentsTool(this, this.toolRegistry, options),
     };
     this.openai = new OpenAITools(this, this.toolRegistry);
     this.anthropic = new AnthropicTools(this, this.toolRegistry);

--- a/src/tools/anthropic.ts
+++ b/src/tools/anthropic.ts
@@ -1,7 +1,9 @@
 import type { Exa } from "../index";
 import {
+  createGetContentsTool,
   createWebSearchTool,
   type ExaToolSpec,
+  type GetContentsToolConfig,
   type WebSearchToolConfig,
   ToolRegistry,
   getTool,
@@ -47,6 +49,11 @@ export class AnthropicTools {
   /** Anthropic `web_search` tool. Defaults to `auto` + highlights. */
   webSearch(config?: WebSearchToolConfig) {
     return runnable(createWebSearchTool(this.exa, this.registry, config));
+  }
+
+  /** Anthropic `get_contents` tool for reading pages by URL. */
+  getContents(config?: GetContentsToolConfig) {
+    return runnable(createGetContentsTool(this.exa, this.registry, config));
   }
 
   /**

--- a/src/tools/core.ts
+++ b/src/tools/core.ts
@@ -45,11 +45,24 @@ export type WebSearchToolConfig = RegularSearchOptions & {
   description?: string;
 };
 
+export type GetContentsToolConfig = ContentsOptions & {
+  /**
+   * Tool name shown to the model. Defaults to `"get_contents"`. Set a custom
+   * name to avoid collisions, or to register multiple differently-configured
+   * contents tools.
+   */
+  name?: string;
+  /** Tool description shown to the model. */
+  description?: string;
+};
+
 export type ToolNamespace = {
   webSearch(config?: WebSearchToolConfig): WebSearchTool;
+  getContents(config?: GetContentsToolConfig): GetContentsTool;
 };
 
 type SearchArgs = { query: string };
+type GetContentsArgs = { urls: string[] };
 type FormattableResult = {
   title?: string | null;
   url?: string;
@@ -57,6 +70,7 @@ type FormattableResult = {
   author?: string;
   highlights?: string[];
   text?: string;
+  summary?: string;
 };
 
 export type WebSearchTool = ExaToolSpec<
@@ -64,11 +78,20 @@ export type WebSearchTool = ExaToolSpec<
   SearchResponse<ContentsOptions>
 >;
 
+export type GetContentsTool = ExaToolSpec<
+  GetContentsArgs,
+  SearchResponse<ContentsOptions>
+>;
+
 export const DEFAULT_WEB_SEARCH_TOOL_DESCRIPTION =
   "Search the web for up-to-date, relevant information. Describe the ideal page rather than listing keywords.";
 
-function formatSearchResponse(
-  response: SearchResponse<ContentsOptions>
+export const DEFAULT_GET_CONTENTS_TOOL_DESCRIPTION =
+  "Read the full contents of web pages you already have URLs for, such as pages returned by a search or mentioned by the user.";
+
+function formatResults(
+  response: SearchResponse<ContentsOptions>,
+  emptyMessage: string
 ): string {
   const formatted = (response.results as FormattableResult[])
     .map((result) => {
@@ -78,6 +101,9 @@ function formatSearchResponse(
         `Published: ${result.publishedDate || "N/A"}`,
         `Author: ${result.author || "N/A"}`,
       ];
+      if (result.summary) {
+        lines.push(`Summary: ${result.summary}`);
+      }
       if (result.highlights && result.highlights.length > 0) {
         lines.push(`Highlights:\n${result.highlights.join("\n")}`);
       } else if (result.text) {
@@ -86,7 +112,19 @@ function formatSearchResponse(
       return lines.join("\n");
     })
     .join("\n\n---\n\n");
-  return formatted || "No search results found.";
+  return formatted || emptyMessage;
+}
+
+function formatSearchResponse(
+  response: SearchResponse<ContentsOptions>
+): string {
+  return formatResults(response, "No search results found.");
+}
+
+function formatContentsResponse(
+  response: SearchResponse<ContentsOptions>
+): string {
+  return formatResults(response, "No contents found.");
 }
 
 function registerTool<T extends ExaToolSpec>(
@@ -175,6 +213,49 @@ export function createWebSearchTool(
     },
     format: formatSearchResponse,
   }) as WebSearchTool;
+}
+
+/**
+ * Create a `get_contents` tool that reads pages the model already has URLs for.
+ * Inherits `exa.getContents` defaults, which return page text when no content
+ * option is configured.
+ */
+export function createGetContentsTool(
+  exa: Exa,
+  registry: ToolRegistry,
+  config: GetContentsToolConfig = {}
+): GetContentsTool {
+  const {
+    name = "get_contents",
+    description = DEFAULT_GET_CONTENTS_TOOL_DESCRIPTION,
+    ...contentsOptions
+  } = config;
+  const inputSchema = z.object({
+    urls: z
+      .array(z.string())
+      .describe(
+        "Absolute URLs of the pages to read, including the scheme. Pass several URLs to read them in a single call."
+      ),
+  });
+  const jsonSchema = zodToJsonSchema(inputSchema) as ToolJsonSchema;
+  delete jsonSchema.$schema;
+
+  return createTool(registry, {
+    name,
+    description,
+    inputSchema,
+    jsonSchema,
+    definition: {
+      name,
+      description,
+      parameters: jsonSchema,
+    },
+    execute: ({ urls }) =>
+      exa.getContents(urls, contentsOptions) as Promise<
+        SearchResponse<ContentsOptions>
+      >,
+    format: formatContentsResponse,
+  }) as GetContentsTool;
 }
 
 export class ToolRegistry {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,8 +1,12 @@
 export {
+  DEFAULT_GET_CONTENTS_TOOL_DESCRIPTION,
   DEFAULT_WEB_SEARCH_TOOL_DESCRIPTION,
   ToolRegistry,
+  createGetContentsTool,
   createWebSearchTool,
   type ExaToolSpec,
+  type GetContentsTool,
+  type GetContentsToolConfig,
   type ToolDefinition,
   type ToolJsonSchema,
   type ToolNamespace,

--- a/src/tools/openai.ts
+++ b/src/tools/openai.ts
@@ -1,7 +1,9 @@
 import type { Exa } from "../index";
 import {
+  createGetContentsTool,
   createWebSearchTool,
   type ExaToolSpec,
+  type GetContentsToolConfig,
   type WebSearchToolConfig,
   type ToolDefinition,
   type ToolJsonSchema,
@@ -145,6 +147,13 @@ export class OpenAIResponsesTools {
     );
   }
 
+  /** Responses API `get_contents` tool for reading pages by URL. */
+  getContents(config?: GetContentsToolConfig) {
+    return responsesRunnable(
+      createGetContentsTool(this.exa, this.registry, config)
+    );
+  }
+
   /**
    * Run the function calls in a Responses API response (or output item array)
    * and return `function_call_output` items. Every function call is answered
@@ -210,6 +219,11 @@ export class OpenAITools {
   /** Chat Completions `web_search` tool. Defaults to `auto` + highlights. */
   webSearch(config?: WebSearchToolConfig) {
     return runnable(createWebSearchTool(this.exa, this.registry, config));
+  }
+
+  /** Chat Completions `get_contents` tool for reading pages by URL. */
+  getContents(config?: GetContentsToolConfig) {
+    return runnable(createGetContentsTool(this.exa, this.registry, config));
   }
 
   /**

--- a/test/unit/tools.test.ts
+++ b/test/unit/tools.test.ts
@@ -561,4 +561,158 @@ describe("LLM tools", () => {
     expect(toolResults[0].type).toBe("tool_result");
     expect(responsesTool.type).toBe("function");
   });
+
+  it("creates a urls-only neutral contents tool", async () => {
+    const request = vi.spyOn(exa, "request").mockResolvedValue({
+      requestId: "request-1",
+      results: [
+        {
+          id: "result-1",
+          title: "Example",
+          url: "https://example.com",
+          text: "Page text",
+        },
+      ],
+    });
+
+    const tool = exa.tools.getContents();
+    expect(tool.name).toBe("get_contents");
+    expect(tool.jsonSchema).toMatchObject({
+      type: "object",
+      required: ["urls"],
+    });
+    expect(tool.jsonSchema).not.toHaveProperty("$schema");
+    expect(tool.definition).not.toHaveProperty("run");
+
+    const output = await tool.run({ urls: ["https://example.com"] });
+    expect(output).toContain("Title: Example");
+    expect(output).toContain("Text: Page text");
+    expect(request).toHaveBeenCalledWith("/contents", "POST", {
+      urls: ["https://example.com"],
+    });
+  });
+
+  it("passes configured contents options through to /contents", async () => {
+    const request = vi.spyOn(exa, "request").mockResolvedValue({
+      requestId: "request-1",
+      results: [
+        {
+          id: "result-1",
+          title: "Example",
+          url: "https://example.com",
+          summary: "A summary",
+        },
+      ],
+    });
+
+    const tool = exa.openai.getContents({
+      name: "read_pages",
+      description: "Read pages",
+      summary: true,
+      livecrawl: "preferred",
+    });
+    const output = await tool.run({
+      urls: ["https://example.com", "https://exa.ai"],
+    });
+
+    expect(output).toContain("Summary: A summary");
+    expect(request).toHaveBeenCalledWith("/contents", "POST", {
+      urls: ["https://example.com", "https://exa.ai"],
+      summary: true,
+      livecrawl: "preferred",
+    });
+    expect(JSON.parse(JSON.stringify(tool))).toEqual({
+      type: "function",
+      function: {
+        name: "read_pages",
+        description: "Read pages",
+        parameters: tool.jsonSchema,
+      },
+    });
+  });
+
+  it("reports empty and failed contents results to the model", async () => {
+    vi.spyOn(exa, "request").mockResolvedValue({
+      requestId: "request-1",
+      results: [],
+    });
+    const tool = exa.tools.getContents();
+    expect(await tool.run({ urls: ["https://example.com"] })).toBe(
+      "No contents found."
+    );
+    expect(await tool.run({ urls: "https://example.com" })).toMatch(/^Error:/);
+  });
+
+  it("serializes contents tools for every provider and handler", async () => {
+    vi.spyOn(exa, "request").mockResolvedValue({
+      requestId: "request-1",
+      results: [
+        {
+          id: "result-1",
+          title: "Example",
+          url: "https://example.com",
+          text: "Page text",
+        },
+      ],
+    });
+    const search = exa.openai.webSearch();
+    const contents = exa.openai.getContents();
+    const responsesTool = exa.openai.responses.getContents();
+    const anthropicTool = exa.anthropic.getContents();
+
+    expect(JSON.parse(JSON.stringify(responsesTool))).toEqual({
+      type: "function",
+      name: "get_contents",
+      description: responsesTool.description,
+      parameters: responsesTool.jsonSchema,
+      strict: false,
+    });
+    expect(JSON.parse(JSON.stringify(anthropicTool))).toEqual({
+      name: "get_contents",
+      description: anthropicTool.description,
+      input_schema: anthropicTool.jsonSchema,
+    });
+
+    const chatMessages = await exa.openai.handleToolCalls({
+      tool_calls: [
+        {
+          id: "call-1",
+          function: { name: search.name, arguments: '{"query":"q"}' },
+        },
+        {
+          id: "call-2",
+          function: {
+            name: contents.name,
+            arguments: '{"urls":["https://example.com"]}',
+          },
+        },
+      ],
+    });
+    expect(chatMessages).toHaveLength(2);
+    expect((chatMessages[1] as { content: string }).content).toContain(
+      "Text: Page text"
+    );
+
+    const responsesOutputs = await exa.openai.responses.handleToolCalls([
+      {
+        type: "function_call",
+        call_id: "call-3",
+        name: responsesTool.name,
+        arguments: '{"urls":["https://example.com"]}',
+      },
+    ]);
+    expect(responsesOutputs[0].output).toContain("Text: Page text");
+
+    const toolResults = await exa.anthropic.handleToolUse({
+      content: [
+        {
+          type: "tool_use",
+          id: "toolu-1",
+          name: anthropicTool.name,
+          input: { urls: ["https://example.com"] },
+        },
+      ],
+    });
+    expect(toolResults[0].content).toContain("Text: Page text");
+  });
 });


### PR DESCRIPTION
## Summary
Adds `getContents` tool helpers alongside `webSearch`, so agents can fetch pages when they already have URLs.

Available in every namespace:
- `exa.tools.getContents()`
- `exa.openai.getContents()`
- `exa.openai.responses.getContents()`
- `exa.anthropic.getContents()`

The model only gets `urls`. The rest of `ContentsOptions` is bound by the developer when the tool is created, so the model can't change crawl/content behavior.

```ts
exa.openai.getContents({ summary: true, livecrawl: "preferred" });
```

Also shares result formatting with search, including summaries and the existing `Highlights` → `Text` fallback.

Tests cover provider schemas, option forwarding, custom names, empty/error results, and tool-call handlers. Tested against the prod `/contents` API before pushing.
